### PR TITLE
Strip single quotes from pp_chunk_b so that parser can parse chunk size

### DIFF
--- a/meta/lib/python/macros/chunkcheck.py
+++ b/meta/lib/python/macros/chunkcheck.py
@@ -78,7 +78,7 @@ class ChunkChecker(metomi.rose.macro.MacroBase):
         # if chunk_b is set, check chunk_a and chunk_b consistency
         pp_chunk_b = config.get_value(['template variables', 'PP_CHUNK_B'])
         if pp_chunk_b:
-            pp_chunk_b = pp_chunk_b.strip('\"') 
+            pp_chunk_b = pp_chunk_b.strip('\"\'') 
             pp_chunk_b_duration = None
             try:
                 pp_chunk_b_duration = parse.DurationParser().parse(pp_chunk_b)


### PR DESCRIPTION
Fixes #22. Turns our my comment in that issue was incorrect, if you string single quotes as well then pp_chunk_b will pass the parser
