### PR TITLE
Change site names to single quotes 

### DIFF
--- a/meta/rose-meta.conf
+++ b/meta/rose-meta.conf
@@ -184,7 +184,7 @@ type=raw
 [template variables=SITE]
 compulsory=true
 title=Label for the site-specific workflow settings; in site/SITE.cylc
-values="ppan", "generic", "gfdl-ws", "gaea"
+values='ppan', 'generic', 'gfdl-ws', 'gaea'
 type=raw
 
 [template variables=DO_ATMOS_PLEVEL_MASKING]


### PR DESCRIPTION
Didn't bother opening up an another issue since this is such a small change, and I mainly made it because I was frustrated by the validator failing every time due to a quoting issue. In any case, this should be more consistent with the new quoting function since it adds single quotes to everything anyways