### PR TITLE
Analysis fixes

### DIFF
--- a/Jinja2Filters/get_analysis_info.py
+++ b/Jinja2Filters/get_analysis_info.py
@@ -200,7 +200,7 @@ R1 = \"\"\"
                 # Looping backwards through all previous chunks.
                 d = date
                 i = -1
-                while d > self.experiment_date_range[0]:
+                while d > self.experiment_date_range[0] + chunk - one_year:
                     if not analysis_only:
                         if self.product == "av":
                             graph += f"& COMBINE-TIMEAVGS-{chunk}[{i*chunk}]:succeed-all\n"

--- a/Jinja2Filters/get_analysis_info.py
+++ b/Jinja2Filters/get_analysis_info.py
@@ -170,7 +170,7 @@ R1 = \"\"\"
 
         if self.script_frequency == chunk and self.date_range == self.experiment_date_range \
            and not self.cumulative:
-            graph += f"{self.script_frequency} = \"\"\"\n"
+            graph += f"+{chunk - one_year}/{self.script_frequency} = \"\"\"\n"
             if analysis_only:
                 graph += f"data-catalog => ANALYSIS-{chunk}?\n"
             else:

--- a/flow.cylc
+++ b/flow.cylc
@@ -108,13 +108,15 @@
     # max number of active cycle points (default 5)
     # this should be something sensible assuming tasks with required outputs
     # (i.e. not marked as "ok to fail") such as analysis scripts.
-    # But until the analysis scripts can be marked optional then let's
-    # set this to be very high, 100 cycle points.
-    runahead limit = P100
+    # But until the analysis scripts can be marked optional then a workaround
+    # is to set this to be very high, ~100 cycle points.
+    # However, the cost of keeping many cycle points active at once are starting
+    # stage-history tasks first, possibly filling /xtmp before the clean tasks run.
+    runahead limit = P20
     [[queues]]
-        # limit the entire workflow to 50 active tasks at once
+        # limit the entire workflow to 100 active tasks at once
         [[[default]]]
-            limit = 50
+            limit = 100
     {# Graph strings are organized by recurrence interval-- when to run the tasks.    #}
     {# Currently, we use 4 intervals: every history-file segment, once (for statics), #}
     {# every chunk-a, and every chunk-b.                                              #}

--- a/flow.cylc
+++ b/flow.cylc
@@ -261,7 +261,7 @@ combine-statics => clean-pp-statics
         # Recurrence interval: every CHUNK-A
         #
         {# Run the tasks to process CHUNK-A every CHUNK-A, starting after PP_CHUNK_A #}
-        +{{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }}/{{ PP_CHUNK_A }} = """
+        +{{ PP_CHUNK_A | subtract_durations('P1Y') }}/{{ PP_CHUNK_A }} = """
 
 {# Tasks can be split over multiple lines if the subsequent ones begin with =>, &, or |                   #}
 {# The make-timeseries tasks for CHUNK-A depend on all segment processing for the time period succeeding. #}
@@ -336,7 +336,7 @@ REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}:succeed-all => data-catalog
 {# If only one pp chunk is used, then skip the CHUNK-B processing. #}
 {% if DO_SECONDARY_PP %}
         {# Run the tasks to process CHUNK-B every CHUNK-B, starting after CHUNK-B time #}
-        +{{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }}/{{ PP_CHUNK_B }} = """
+        +{{ PP_CHUNK_B | subtract_durations('P1Y') }}/{{ PP_CHUNK_B }} = """
 
 {# The make-timeseries tasks for CHUNK-B depend on all CHUNK-A processing for the time period succeeding. #}
     {% if DO_REGRID %}


### PR DESCRIPTION
A couple tiny fixes that allow the task graphing to work properly, and a little adjusting of the job limiters.

changes to get_analysis_info.py
- line 173: The existing recurrence interval was not right, and only happened to work because our history segment sizes are almost always 1 year. Fixing this allows the analysis recurrence intervals and the pp chunk intervals to align- otherwise tasks are floating and disconnected.
- line 203: The cumulative-mode analysis scripts were not right before, depending on pp tasks too far back in time.

change to flow.cylc
- line 266: The corresponding change to get_analysis_info's line 173 change
- minor adjustments to the job limiter settings that are probably a good idea (and we can change later)