### PR TITLE
Various

### DIFF
--- a/Jinja2Filters/form_remap_dep.py
+++ b/Jinja2Filters/form_remap_dep.py
@@ -1,6 +1,7 @@
 import re
 import os
 import metomi.rose.config
+import ast
 """! form_remap_dep parses the remap_pp_components rose-app.conf and uses input from rose-suite.conf in the form of
 env variables and returns the pp component and source name dependencies for remap_pp_components task execution. For 
 instance, for an atmos PP component that requires the regridded atmos_month and regridded atmos_daily history 
@@ -107,7 +108,7 @@ def form_remap_dep(grid_type: str, temporal_type: str, chunk: str, pp_components
                #print("DEBUG: Skipping as {} is requested, but not in rose-app config {}:".format(chunk, chunk_from_config))
                continue
 
-        results = node.get_value(keys=[item, 'sources']).split()
+        results = ast.literal_eval(node.get_value(keys=[item, 'sources']))
         remap_comp = comp
         answer = sorted(list(set(results)))
         if remap_comp is not None:

--- a/Jinja2Filters/form_task_parameters.py
+++ b/Jinja2Filters/form_task_parameters.py
@@ -1,6 +1,13 @@
 import re
 import os
 import metomi.rose.config
+import ast
+
+# set up logging
+import logging
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 def form_task_parameters(grid_type, temporal_type, pp_components_str):
     """Form the task parameter list based on the grid type, the temporal type,
@@ -11,8 +18,8 @@ def form_task_parameters(grid_type, temporal_type, pp_components_str):
         temporal_type (str): One of: temporal or static
         pp_component (str): all, or a space-separated list
 """
+    logger.debug(f"Desired pp components: {pp_components_str}")
     pp_components = pp_components_str.split()
-    #print("DEBUG: desired pp components:", pp_components)
     path_to_conf = os.path.dirname(os.path.abspath(__file__)) + '/../app/remap-pp-components/rose-app.conf'
     node = metomi.rose.config.load(path_to_conf)
     results = []
@@ -27,15 +34,16 @@ def form_task_parameters(grid_type, temporal_type, pp_components_str):
         if item == "env" or item == "command":
             continue
         comp = regex_pp_comp.match(item).group()
-        #print("DEBUG: Examining", item, comp)
+        logger.debug(f"Examining item '{item}' comp '{comp}'")
 
         # skip if pp component not desired
-        if "all" not in pp_components:
-            #print("DEBUG: PP COMP", pp_components, "COMP is", comp)
-            if comp not in pp_components: 
-       		#print("DEBUG2: comp not in pp_components", pp_components, "and", comp)
-                continue
-        #print("DEBUG: Examining", item, comp)
+        logger.debug(f"Is {comp} in {pp_components}?")
+        if comp in pp_components: 
+            logger.debug('Yes')
+            pass
+        else:
+            loger.debug('No')
+            continue
 
         # skip if grid type is not desired
         # some grid types (i.e. regrid-xy) have subtypes (i.e. 1deg, 2deg)
@@ -43,7 +51,7 @@ def form_task_parameters(grid_type, temporal_type, pp_components_str):
         # So we will strip off after the slash and the remainder is the grid type
         candidate_grid_type = re.sub('\/.*', '', node.get_value(keys=[item, 'grid']))
         if candidate_grid_type != grid_type:
-            #print("DEBUG: Skipping as not right grid; got", candidate_grid_type, "and wanted", grid_type)
+            logger.debug(f"Skipping as not right grid; got '{candidate_grid_type}' and wanted '{grid_type}'")
             continue
 
         # filter static and temporal
@@ -52,22 +60,23 @@ def form_task_parameters(grid_type, temporal_type, pp_components_str):
         # if freq does not include "P0Y" => temporal
         freq = node.get_value(keys=[item, 'freq'])
         if freq is not None and 'P0Y' in freq and temporal_type == 'temporal':
-            #print("DEBUG: Skipping static when temporal is requested")
+            logger.debug("Skipping static when temporal is requested")
             continue
         if temporal_type == "static":
             if freq is not None and 'P0Y' not in freq:
-                #print("DEBUG: Skipping as static is requested, no P0Y here", freq)
+                logger.debug("Skipping as static is requested, no P0Y here", freq)
                 continue
         elif (temporal_type == "temporal"):
             if freq is not None and 'P0Y' in freq:
-                #print("DEBUG: Skipping as temporal is requested, P0Y here", freq)
+                logger.debug("Skipping as temporal is requested, P0Y here", freq)
                 continue
         else:
             raise Exception("Unknown temporal type:", temporal_type)
 
-        results = results + node.get_value(keys=[item, 'sources']).split()
+        # convert array in string form to array
+        sources = ast.literal_eval(node.get_value(keys=[item, 'sources']))
+        results.extend(sources)
 
     answer = sorted(list(set(results)))
+    logger.debug("Returning string" + ', '.join(answer))
     return(', '.join(answer))
-
-#print(form_task_parameters('native', 'temporal', 'land atmos land_cubic'))

--- a/Jinja2Filters/form_task_parameters.py
+++ b/Jinja2Filters/form_task_parameters.py
@@ -40,9 +40,8 @@ def form_task_parameters(grid_type, temporal_type, pp_components_str):
         logger.debug(f"Is {comp} in {pp_components}?")
         if comp in pp_components: 
             logger.debug('Yes')
-            pass
         else:
-            loger.debug('No')
+            logger.debug('No')
             continue
 
         # skip if grid type is not desired

--- a/app/combine-timeavgs/bin/combine-timeavgs
+++ b/app/combine-timeavgs/bin/combine-timeavgs
@@ -63,16 +63,6 @@ if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
     echo "Set PYTHONPATH and created i/o lists"
 fi
 
-# Convert currentChunk in ISO to Bronx
-if [[ $currentChunk =~ ^P([0-9]+)Y$ ]]; then
-    currentChunkBronx=${BASH_REMATCH[1]}yr
-elif [[ $currentChunk =~ ^P([0-9]+)M$ ]]; then
-    currentChunkBronx=${BASH_REMATCH[1]}mon
-else
-   echo "ERROR: Could not convert ISO chunk '$currentChunk'"
-   exit 2
-fi
-
 # Exit early, with appearence of success, if the component directory does not exist
 # This means the make-timeavgs task did not work, which almost certainly means that
 # the source files are not monthly or annual, which are the only currently supported
@@ -99,7 +89,7 @@ for freq in $(ls); do
     fi
 
     # create output dir
-    subdir=$(form_av_dirs $freq $currentChunkBronx)
+    subdir=$(form_av_dirs $freq $currentChunk)
     mkdir -p $outputDir/$subdir
 
 
@@ -118,7 +108,7 @@ for freq in $(ls); do
         cdo -O splitmon $component.$dates.nc $outputDir/$subdir/$component.$dates.
         
         if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunkBronx
+            input_dir_path=$inputDir/$component/$freq/$currentChunk
             output_dir_path=$outputDir/$subdir
             
             start_time=$(date +%s)

--- a/app/combine-timeavgs/bin/combine-timeavgs
+++ b/app/combine-timeavgs/bin/combine-timeavgs
@@ -84,7 +84,7 @@ fi
 cd $inputDir/$component
 
 for freq in $(ls); do
-    pushd $freq/$currentChunkBronx
+    pushd $freq/$currentChunk
 
     # workaround to target YYYY files if chunkSize is P1Y
     if [[ $currentChunk == P1Y ]]; then
@@ -146,7 +146,7 @@ for freq in $(ls); do
         fi
 
         if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunkBronx
+            input_dir_path=$inputDir/$component/$freq/$currentChunk
             output_dir_path=$outputDir/$subdir
             output_file=$component.$dates.ann.nc
 

--- a/app/combine-timeavgs/bin/combine-timeavgs
+++ b/app/combine-timeavgs/bin/combine-timeavgs
@@ -63,6 +63,16 @@ if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
     echo "Set PYTHONPATH and created i/o lists"
 fi
 
+# Convert currentChunk in ISO to Bronx
+if [[ $currentChunk =~ ^P([0-9]+)Y$ ]]; then
+    currentChunkBronx=${BASH_REMATCH[1]}yr
+elif [[ $currentChunk =~ ^P([0-9]+)M$ ]]; then
+    currentChunkBronx=${BASH_REMATCH[1]}mon
+else
+   echo "ERROR: Could not convert ISO chunk '$currentChunk'"
+   exit 2
+fi
+
 # Exit early, with appearence of success, if the component directory does not exist
 # This means the make-timeavgs task did not work, which almost certainly means that
 # the source files are not monthly or annual, which are the only currently supported
@@ -74,7 +84,7 @@ fi
 cd $inputDir/$component
 
 for freq in $(ls); do
-    pushd $freq/$currentChunk
+    pushd $freq/$currentChunkBronx
 
     # workaround to target YYYY files if chunkSize is P1Y
     if [[ $currentChunk == P1Y ]]; then
@@ -89,7 +99,7 @@ for freq in $(ls); do
     fi
 
     # create output dir
-    subdir=$(form_av_dirs $freq $currentChunk)
+    subdir=$(form_av_dirs $freq $currentChunkBronx)
     mkdir -p $outputDir/$subdir
 
 
@@ -108,7 +118,7 @@ for freq in $(ls); do
         cdo -O splitmon $component.$dates.nc $outputDir/$subdir/$component.$dates.
         
         if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunk
+            input_dir_path=$inputDir/$component/$freq/$currentChunkBronx
             output_dir_path=$outputDir/$subdir
             
             start_time=$(date +%s)
@@ -136,7 +146,7 @@ for freq in $(ls); do
         fi
 
         if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunk
+            input_dir_path=$inputDir/$component/$freq/$currentChunkBronx
             output_dir_path=$outputDir/$subdir
             output_file=$component.$dates.ann.nc
 

--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -326,8 +326,7 @@ def remap():
                 if fields.get("freq") is None:
                     freq = glob.glob("*")
                 else:
-                    freq = fields.get("freq").get_value()
-                    freq = freq.split()
+                    freq = ast.literal_eval(fields.get("sources").get_value())
 
                 for f in freq:
                     if ens_mem is not None:
@@ -339,8 +338,7 @@ def remap():
                     if fields.get("chunk") is None:
                         chunk = glob.glob("*")
                     else:
-                        chunk = fields.get("chunk").get_value()
-                        chunk = chunk.split()
+                        chunk = ast.literal_eval(fields.get("chunk").get_value())
 
                     for c in chunk:
                         if c != current_chunk:
@@ -357,14 +355,14 @@ def remap():
                             dirs = create_dir(out_dir = output_dir,
                                               comp = comp,
                                               freq = freq_to_legacy(f),
-                                              chunk = chunk_to_legacy(chunk),
+                                              chunk = chunk_to_legacy(c),
                                               ens = ens_mem,
                                               dir_ts = dir_ts_workaround)
                         else:
                             dirs = create_dir(out_dir = output_dir,
                                               comp = comp,
                                               freq = f,
-                                              chunk = chunk,
+                                              chunk = c,
                                               ens = ens_mem,
                                               dir_ts = dir_ts_workaround)
 

--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -11,6 +11,7 @@ import subprocess
 import glob
 from pathlib import Path
 import metomi.rose.config as mrc
+import ast
 
 def verify_dirs(in_dir,out_dir):
     """
@@ -96,7 +97,7 @@ def freq_to_legacy(iso_dura):
     elif iso_dura=='PT30M':
         freq_legacy = '30min'
     else:
-        freq_legacy = 'error'
+        raise ValueError("Could not convert ISO duration '{iso_dura}'")
 
     return freq_legacy
 
@@ -118,37 +119,6 @@ def chunk_to_legacy(iso_dura):
         brx_freq = 'error'
 
     return brx_freq
-
-def bronx_style(freq, chunk, ens_member, out_dir, comp):
-    """
-    Create bronx-style symlinks
-    Params:
-        freq: frequency
-        chunk: chunk
-        ens_member: ensemble member
-        out_dir: output directory
-        comp: component
-    """
-
-    freq_legacy = freq_to_legacy(freq)
-    chunk_legacy = chunk_to_legacy(chunk)
-    if chunk_legacy == "error":
-        print(f"Error: Skipping legacy directory for chunk: {chunk}")
-    else:
-        if ens_member is not None:
-            dir1 = f"{out_dir}/{comp}/ts/{ens_member}"
-            os.chdir(f"{out_dir}/{comp}/ts/{ens_member}")
-        else:
-            dir1 = f"{out_dir}/{comp}/ts"
-            os.chdir(f"{out_dir}/{comp}/ts")
-
-        Path(freq_legacy).mkdir(exist_ok=True)
-        os.chdir(freq_legacy)
-
-        if not Path(chunk_legacy).exists():
-            os.symlink(f"{dir1}/{freq}/{chunk}", chunk_legacy)
-
-    return dir1
 
 def freq_to_date_format(iso_freq):
     """
@@ -333,11 +303,8 @@ def remap():
                 os.chdir(f"{input_dir}/{g}")
 
             ## SOURCES
-            if fields.get("sources") is None:
-                sources = glob.glob("*")
-            else:
-                sources = fields.get("sources").get_value()
-                sources = sources.split()
+            # convert ascii array to array
+            sources = ast.literal_eval(fields.get("sources").get_value())
 
             for s in sources:
                 # Start in grid directory
@@ -384,22 +351,24 @@ def remap():
                             os.chdir(f"{input_dir}/{g}/{s}/{f}/{c}")
 
                         # Create directory
-                        dirs = create_dir(out_dir = output_dir,
-                                          comp = comp,
-                                          freq = f,
-                                          chunk = c,
-                                          ens = ens_mem,
-                                          dir_ts = dir_ts_workaround)
+                        # ts output is written to final location, av is not.
+                        # so convert the ts only to bronx-style
+                        if product == "ts":
+                            dirs = create_dir(out_dir = output_dir,
+                                              comp = comp,
+                                              freq = freq_to_legacy(f),
+                                              chunk = chunk_to_legacy(chunk),
+                                              ens = ens_mem,
+                                              dir_ts = dir_ts_workaround)
+                        else:
+                            dirs = create_dir(out_dir = output_dir,
+                                              comp = comp,
+                                              freq = f,
+                                              chunk = chunk,
+                                              ens = ens_mem,
+                                              dir_ts = dir_ts_workaround)
 
                         print(f"directory created: {dirs}")
-
-                        # Create bronx-style symlinks for TS only
-                        if dir_ts_workaround:
-                            bronx_style(freq = f,
-                                        chunk = c,
-                                        ens_member = ens_mem,
-                                        out_dir = output_dir,
-                                        comp = comp)
 
                         # Search for files in chunk directory
                         if ens_mem is not None:

--- a/flow.cylc
+++ b/flow.cylc
@@ -925,8 +925,6 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[data-catalog]]
         script = """
         fre catalog builder --overwrite $ppdir $ppdir/catalog
-        # workaround to replace P1M with monthly
-        sed -i.bak -e 's/,P1M,/,monthly,/' $ppdir/catalog.csv
         """
         # when many data catalog jobs run simultaneously, they can fail
         # this is not a good solution here

--- a/flow.cylc
+++ b/flow.cylc
@@ -821,7 +821,8 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 {% endif %}
 
     [[REMAP-PP-COMPONENTS]]
-        script = rose task-run --verbose --app-key remap-pp-components
+        # 'rose task-run' should work, but does not in the fre-cli conda environment (activated by this task)
+        script = rose-task-run --verbose --app-key remap-pp-components
         [[[environment]]]
             components = $CYLC_TASK_PARAM_component
 
@@ -999,7 +1000,8 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 {% if DO_REGRID %}
     [[REGRID-XY]]
         pre-script = mkdir -p $outputDir
-        script = rose task-run --verbose --app-key regrid-xy
+        # 'rose task-run' should work, but does not in the fre-cli conda environment (activated by this task)
+        script = rose-task-run --verbose --app-key regrid-xy
         [[[environment]]]
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
             outputDir = $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/regrid-xy

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -96,10 +96,15 @@
 {% if DO_REGRID %}
     [[REGRID-XY]]
         pre-script = """
-            module load fre-nctools miniforge
+            # the conda activate below brings in an old fre-nctools
+            # that is conda installable. we need an updated
+            # fre-nctools to regrid new ocean output
+            module load miniforge
             set +u
             conda activate /nbhome/fms/conda/envs/fre-2025.01
             set -u
+            module load fre-nctools/2024.05
+            which fregrid
             mkdir -p $outputDir
         """
 {% endif %}

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -144,10 +144,15 @@
 {% if DO_REGRID %}
     [[REGRID-XY]]
         pre-script = """
-            module load fre-nctools miniforge
+            # the conda activate below brings in an old fre-nctools
+            # that is conda installable. we need an updated
+            # fre-nctools to regrid new ocean output
+            module load miniforge
             set +u
             conda activate /nbhome/fms/conda/envs/fre-2025.01
             set -u
+            module load fre-nctools/2024.05
+            which fregrid
             mkdir -p $outputDir
         """
 {% endif %}


### PR DESCRIPTION
1. Parse history file lists as proper lists (instead of space-separated strings) and parse years as integers if specified as ints (will be ISO otherwise)
2. Add logging
3. remap-pp-components: write TS output in Bronx format which obviates need for symlinks (which data catalog does not accept). keep TA output in ISO format, which is not directly written to /archive. (combine-timeaverages does that).
4. Use updated fre-nctools instead of the older and out of date conda package version