### PR TITLE
Support remainder PP chunks

### DIFF
--- a/Jinja2Filters/form_remap_dep.py
+++ b/Jinja2Filters/form_remap_dep.py
@@ -56,7 +56,7 @@ def form_remap_dep(grid_type: str,
     # Note: history_segment should be specified for primary chunk generation,
     # and omitted for secondary chunk generation.
     if output_type == "ts":
-        if history_segment == chunk:
+        if str(history_segment) == str(chunk):
             prereq_task = "rename-split-to-pp"
         else:
             prereq_task = "make-timeseries"

--- a/Jinja2Filters/iter_chunks.py
+++ b/Jinja2Filters/iter_chunks.py
@@ -2,7 +2,7 @@ from metomi.isodatetime.parsers import DurationParser, TimePointParser
 
 def iter_chunks(chunk_sizes, history_segment, pp_start, pp_stop):
     """Return an iterator over all PP chunks. For each chunk, a dictionary is
-       yielded consisting of `chunk_size`, `cycle_point`, and `segments` keys.
+       yielded consisting of `chunk_size`, `cycle_point`, `segments`, and `is_partial` keys.
 
     Arguments:
         chunk_sizes (list of strings)
@@ -17,17 +17,20 @@ def iter_chunks(chunk_sizes, history_segment, pp_start, pp_stop):
       {
         'chunk_size': Duration<P2Y>,
         'cycle_point': TimePoint<0001-01-01>,
-        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>]
+        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>],
+        'is_partial': False
       },
       {
         'chunk_size': Duration<P2Y>,
         'cycle_point': TimePoint<0003-01-01>,
-        'segments': [TimePoint<0003-01-01>]
+        'segments': [TimePoint<0003-01-01>],
+        'is_partial': True
       },
       {
         'chunk_size': Duration<P3Y>,
         'cycle_point': TimePoint<0001-01-01>,
-        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>, TimePoint<0003-01-01>]
+        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>, TimePoint<0003-01-01>],
+        'is_partial': False
       }
     ]
 """
@@ -51,6 +54,7 @@ def iter_chunks(chunk_sizes, history_segment, pp_start, pp_stop):
             yield {
                 'chunk_size': cs,
                 'cycle_point': cycle_point,
-                'segments': [cycle_point + history_segment*i for i in range(n)]
+                'segments': [cycle_point + history_segment*i for i in range(n)],
+                'is_partial': False if n == n_segments_full_chunk else True
             }
             cycle_point += cs

--- a/Jinja2Filters/iter_chunks.py
+++ b/Jinja2Filters/iter_chunks.py
@@ -1,0 +1,56 @@
+from metomi.isodatetime.parsers import DurationParser, TimePointParser
+
+def iter_chunks(chunk_sizes, history_segment, pp_start, pp_stop):
+    """Return an iterator over all PP chunks. For each chunk, a dictionary is
+       yielded consisting of `chunk_size`, `cycle_point`, and `segments` keys.
+
+    Arguments:
+        chunk_sizes (list of strings)
+        history_segment (string)
+        pp_start (string)
+        pp_stop (string)
+
+    Example:
+    >>> list(iter_chunks(["P2Y", "P3Y"], "P1Y", "0001", "0003"))
+    Result:
+    [
+      {
+        'chunk_size': Duration<P2Y>,
+        'cycle_point': TimePoint<0001-01-01>,
+        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>]
+      },
+      {
+        'chunk_size': Duration<P2Y>,
+        'cycle_point': TimePoint<0003-01-01>,
+        'segments': [TimePoint<0003-01-01>]
+      },
+      {
+        'chunk_size': Duration<P3Y>,
+        'cycle_point': TimePoint<0001-01-01>,
+        'segments': [TimePoint<0001-01-01>, TimePoint<0002-01-01>, TimePoint<0003-01-01>]
+      }
+    ]
+"""
+    duration_parser = DurationParser()
+    time_point_parser = TimePointParser(default_to_unknown_time_zone=True)
+
+    chunk_sizes = (duration_parser.parse(cs) for cs in chunk_sizes)
+    history_segment = duration_parser.parse(history_segment)
+    pp_start = time_point_parser.parse(pp_start)
+    pp_stop = time_point_parser.parse(pp_stop)
+
+    def n_segments(interval):
+        return int(interval.get_seconds() / history_segment.get_seconds())
+
+    for cs in chunk_sizes:
+        n_segments_full_chunk = n_segments(cs)
+        cycle_point = pp_start
+        while cycle_point <= pp_stop:
+            n_segments_remaining = n_segments(pp_stop + history_segment - cycle_point)
+            n = min(n_segments_full_chunk, n_segments_remaining)
+            yield {
+                'chunk_size': cs,
+                'cycle_point': cycle_point,
+                'segments': [cycle_point + history_segment*i for i in range(n)]
+            }
+            cycle_point += cs

--- a/app/make-timeavgs/bin/make-timeavgs
+++ b/app/make-timeavgs/bin/make-timeavgs
@@ -56,7 +56,7 @@ for dir in ${dirs[@]}; do
 
 	#now need to pick the right date-time format for the cycle-point
 	if [[ $file_freq == P1M ]]; then
-		cyclepoint=$(cylc cycle-point --template CCYY12)
+		cyclepoint=$(cylc cycle-point --template CCYYMM)
         tool_args=month
 	elif [[ $file_freq == P1Y ]]; then
 		cyclepoint=$(cylc cycle-point --template CCYY)
@@ -66,7 +66,7 @@ for dir in ${dirs[@]}; do
 		continue
 	fi
 															   
-	files=($(ls $dir/$interval/$component.*-$cyclepoint.*.nc))
+	files=($(ls $dir/$interval/$component.$cyclepoint-*.*.nc))
 	if [[ ${#files[@]} -lt 1 ]]; then
 		echo "---WARNING--- no files found in directory $dir!"
 		echo "moving on to next directory..."

--- a/app/make-timeseries/bin/make-timeseries
+++ b/app/make-timeseries/bin/make-timeseries
@@ -137,14 +137,14 @@ type isodatetime
 # Determine how many expected files to concatenate
 inputChunkHrs=$(isodatetime --as-total=H $inputChunk | sed -e 's/\.0$//')
 expectedChunks=$(( $(isodatetime --as-total=H $outputChunk | sed -e 's/\.0$//') / inputChunkHrs ))
-availChunks=$(( $(isodatetime --as-total=H $begin $pp_stop | sed -e 's/\.0$//') / inputChunkHrs ))
+availChunks=$(( $(isodatetime --as-total=H $begin $pp_stop --offset2=$inputChunk | sed -e 's/\.0$//') / inputChunkHrs ))
 
 if ((availChunks >= expectedChunks))
 then
     end=$(isodatetime $begin --offset $outputChunk)
 else
     expectedChunks=$availChunks
-    end=$pp_stop
+    end=$(isodatetime $pp_stop --offset $inputChunk)
 fi
 
 if (( expectedChunks > 0 )); then

--- a/app/make-timeseries/bin/make-timeseries
+++ b/app/make-timeseries/bin/make-timeseries
@@ -126,6 +126,7 @@ echo "    output dir: $outputDir"
 echo "    begin: $begin"
 echo "    input chunk: $inputChunk"
 echo "    output chunk: $outputChunk"
+echo "    pp stop: $pp_stop"
 echo "    component: $component"
 echo "    components allowed to fail: ${fail_ok_components:=}"
 echo "    use subdirs: ${use_subdirs:=}"
@@ -134,7 +135,18 @@ type cdo
 type isodatetime
 
 # Determine how many expected files to concatenate
-expectedChunks=$(( $(isodatetime --as-total=H $outputChunk | sed -e 's/\.0$//') / $(isodatetime --as-total=H $inputChunk | sed -e 's/\.0$//') ))
+inputChunkHrs=$(isodatetime --as-total=H $inputChunk | sed -e 's/\.0$//')
+expectedChunks=$(( $(isodatetime --as-total=H $outputChunk | sed -e 's/\.0$//') / inputChunkHrs ))
+availChunks=$(( $(isodatetime --as-total=H $begin $pp_stop | sed -e 's/\.0$//') / inputChunkHrs ))
+
+if ((availChunks >= expectedChunks))
+then
+    end=$(isodatetime $begin --offset $outputChunk)
+else
+    expectedChunks=$availChunks
+    end=$pp_stop
+fi
+
 if (( expectedChunks > 0 )); then
     echo NOTE: Expect to concatenate $expectedChunks subchunks
 else
@@ -161,8 +173,6 @@ if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
     echo "Set PYTHONPATH and created i/o lists"
 fi
 
-# Calculate end date
-end=$(isodatetime $begin --offset $outputChunk)
 # remove trailing Z to allow string comparison later
 begin=${begin%Z}
 end=${end%Z}

--- a/flow.cylc
+++ b/flow.cylc
@@ -282,7 +282,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             {% for SEGMENT in chunk.segments[1:] %}
                 & rename-split-to-pp-regrid<regrid>[{{ SEGMENT }}]
             {% endfor %}
-            {% if HISTORY_SEGMENT != chunk.chunk_size %}
+            {% if HISTORY_SEGMENT != chunk.chunk_size | string %}
                 => make-timeseries-regrid-{{ chunk.chunk_size }}<regrid>
             {% endif %}
             {% if DO_TIMEAVGS and not chunk.is_partial %}
@@ -295,7 +295,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             {% for SEGMENT in chunk.segments[1:] %}
                 & rename-split-to-pp-native<native>[{{ SEGMENT }}]
             {% endfor %}
-            {% if HISTORY_SEGMENT != chunk.chunk_size %}
+            {% if HISTORY_SEGMENT != chunk.chunk_size | string %}
                 => make-timeseries-native-{{ chunk.chunk_size }}<native>
             {% endif %}
             {% if DO_TIMEAVGS and not chunk.is_partial %}
@@ -1027,9 +1027,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         inherit = CLEAN
         script = """
             rm -rf $CYLC_WORKFLOW_SHARE_DIR/shards/ts/native/*/P0Y
-    {% if DO_REGRID %}
             rm -rf $CYLC_WORKFLOW_SHARE_DIR/shards/ts/regrid-xy/*/*/P0Y
-    {% endif %}
         """
 {% endif %}
 
@@ -1038,9 +1036,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/ts/native/*/*/{{ HISTORY_SEGMENT }} $CYLC_WORKFLOW_SHARE_DIR/shards/ts/regrid-xy/*/*/*/{{ HISTORY_SEGMENT }}"
             for dir in $dirs; do
-                if ls $dir; then
-                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                fi
+                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
             done
         """
 
@@ -1049,12 +1045,10 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_A }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_A }}"
             for dir in $dirs; do
-                if ls $dir; then
-                    if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                    else
-                        find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                    fi
+                if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
+                else
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
                 fi
             done
         """
@@ -1065,9 +1059,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_B }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_B }}"
             for dir in $dirs; do
-                if ls $dir; then
-                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                fi
+                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
             done
         """
 {% endif %}
@@ -1077,12 +1069,10 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs=$CYLC_WORKFLOW_SHARE_DIR/pp/av/*/*/{{ PP_CHUNK_A }}
             for dir in $dirs; do
-                if ls $dir; then
-                    if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                        find $dir -type f -name "*.$(cylc cycle-point   --template CCYY)*.nc" -print -delete
-                    else
-                        find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                    fi
+                if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
+                else
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
                 fi
             done
         """
@@ -1093,9 +1083,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs=$CYLC_WORKFLOW_SHARE_DIR/pp/av/*/*/{{ PP_CHUNK_B }}
             for dir in $dirs; do
-                if ls $dir; then
-                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                fi
+                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
             done
         """
 {% endif %}

--- a/flow.cylc
+++ b/flow.cylc
@@ -263,7 +263,7 @@ combine-statics => clean-pp-statics
         # Recurrence interval: every CHUNK-A
         #
         {# Run the tasks to process CHUNK-A every CHUNK-A, starting after PP_CHUNK_A #}
-        +{{ PP_CHUNK_A | subtract_durations('P1Y') }}/{{ PP_CHUNK_A }} = """
+        {{ PP_CHUNK_A }} = """
 
 {# Tasks can be split over multiple lines if the subsequent ones begin with =>, &, or |                   #}
 {# The make-timeseries tasks for CHUNK-A depend on all segment processing for the time period succeeding. #}
@@ -271,7 +271,7 @@ combine-statics => clean-pp-statics
 {% if DO_REGRID %}
 rename-split-to-pp-regrid<regrid>
     {% for SEGMENT in range(1, HIST_SEGMENTS_PER_CHUNK_A) %}
-& rename-split-to-pp-regrid<regrid>[{{ HISTORY_SEGMENT | multiply_duration(-SEGMENT) }}]
+& rename-split-to-pp-regrid<regrid>[{{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }}]
     {% endfor %}
     {% if HISTORY_SEGMENT != PP_CHUNK_A %}
 => make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>
@@ -284,7 +284,7 @@ rename-split-to-pp-regrid<regrid>
 {% if DO_NATIVE %}
 rename-split-to-pp-native<native>
     {% for SEGMENT in range(1, HIST_SEGMENTS_PER_CHUNK_A) %}
-& rename-split-to-pp-native<native>[{{ HISTORY_SEGMENT | multiply_duration(-SEGMENT) }}]
+& rename-split-to-pp-native<native>[{{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }}]
     {% endfor %}
     {% if HISTORY_SEGMENT != PP_CHUNK_A %}
 => make-timeseries-native-{{ PP_CHUNK_A }}<native>
@@ -338,7 +338,7 @@ REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}:succeed-all => data-catalog
 {# If only one pp chunk is used, then skip the CHUNK-B processing. #}
 {% if DO_SECONDARY_PP %}
         {# Run the tasks to process CHUNK-B every CHUNK-B, starting after CHUNK-B time #}
-        +{{ PP_CHUNK_B | subtract_durations('P1Y') }}/{{ PP_CHUNK_B }} = """
+        {{ PP_CHUNK_B }} = """
 
 {# The make-timeseries tasks for CHUNK-B depend on all CHUNK-A processing for the time period succeeding. #}
     {% if DO_REGRID %}
@@ -349,9 +349,9 @@ make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>
         {% endif %}
         {% for CHUNK in range(1, CHUNK_AS_PER_CHUNK_B) %}
         {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-& rename-split-to-pp-regrid<regrid>[{{ PP_CHUNK_A | multiply_duration(-CHUNK)}}]
+& rename-split-to-pp-regrid<regrid>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
         {% else %}
-& make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>[{{ PP_CHUNK_A | multiply_duration(-CHUNK)}}]
+& make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
         {% endif %}
         {% endfor %}
 => make-timeseries-regrid-{{ PP_CHUNK_B }}<regrid>
@@ -368,9 +368,9 @@ make-timeseries-native-{{ PP_CHUNK_A }}<native>
         {% endif %}
         {% for CHUNK in range(1, CHUNK_AS_PER_CHUNK_B) %}
         {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-& rename-split-to-pp-native<native>[{{ PP_CHUNK_A | multiply_duration(-CHUNK)}}]
+& rename-split-to-pp-native<native>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
         {% else %}
-& make-timeseries-native-{{ PP_CHUNK_A }}<native>[{{ PP_CHUNK_A | multiply_duration(-CHUNK)}}]
+& make-timeseries-native-{{ PP_CHUNK_A }}<native>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
         {% endif %}
         {% endfor %}
 => make-timeseries-native-{{ PP_CHUNK_B }}<native>
@@ -836,7 +836,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}]]
         inherit = REMAP-PP-COMPONENTS-TS
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             currentChunk = {{ PP_CHUNK_A }}
     [[remap-pp-components-ts-{{ PP_CHUNK_A }}<component>]]
         inherit = REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}, <component>
@@ -845,7 +845,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}]]
         inherit = REMAP-PP-COMPONENTS-TS
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             currentChunk = {{ PP_CHUNK_B }}
     [[remap-pp-components-ts-{{ PP_CHUNK_B }}<component>]]
         inherit = REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}, <component>
@@ -861,7 +861,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_A }}]]
         inherit = REMAP-PP-COMPONENTS-AV
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             currentChunk = {{ PP_CHUNK_A }}
     [[remap-pp-components-av-{{ PP_CHUNK_A }}<component>]]
         inherit = REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_A }}, <component>
@@ -870,7 +870,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}]]
         inherit = REMAP-PP-COMPONENTS-AV
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             currentChunk = {{ PP_CHUNK_B }}
     [[remap-pp-components-av-{{ PP_CHUNK_B }}<component>]]
         inherit = REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}, <component>
@@ -888,7 +888,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
         inherit = COMBINE-TIMEAVGS
         [[[environment]]]
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }} --print-year)
+            begin = $(cylc cycle-point --print-year)
             currentChunk = {{ PP_CHUNK_A }}
     [[combine-timeavgs-{{ PP_CHUNK_A }}<component>]]
         inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}, <component>
@@ -900,7 +900,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
         inherit = COMBINE-TIMEAVGS
         [[[environment]]]
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }} --print-year)
+            begin = $(cylc cycle-point --print-year)
             currentChunk = {{ PP_CHUNK_B }}
     [[combine-timeavgs-{{ PP_CHUNK_B }}<component>]]
         inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_B }}, <component>
@@ -958,7 +958,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 
     [[MAKE-TIMESERIES-{{ PP_CHUNK_A }}]]
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             inputChunk = {{ HISTORY_SEGMENT }}
             outputChunk = {{ PP_CHUNK_A }}
 {% if DO_NATIVE %}
@@ -977,7 +977,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 {% if DO_SECONDARY_PP %}
     [[MAKE-TIMESERIES-{{ PP_CHUNK_B }}]]
         [[[environment]]]
-            begin = $(cylc cycle-point --offset=-{{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }})
+            begin = $(cylc cycle-point)
             inputChunk = {{ PP_CHUNK_A }}
             outputChunk = {{ PP_CHUNK_B }}
     {% if DO_NATIVE %}
@@ -1114,7 +1114,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
             for dir in $dirs; do
                 if ls $dir; then
 {% for SEGMENT in range(0, HIST_SEGMENTS_PER_CHUNK_A) %}
-                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ HISTORY_SEGMENT | multiply_duration(-SEGMENT) }})*.nc" -print -delete
+                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }})*.nc" -print -delete
 {% endfor %}
                 fi
             done
@@ -1129,9 +1129,9 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 {% if DO_SECONDARY_PP %}
     {% for CHUNK in range(0, CHUNK_AS_PER_CHUNK_B) %}
                     if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY   --offset={{ PP_CHUNK_A | multiply_duration(-CHUNK) }})*.nc" -print -delete
+                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY   --offset={{ PP_CHUNK_A | multiply_duration(CHUNK) }})*.nc" -print -delete
                     else
-                        find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ PP_CHUNK_A | multiply_duration(-CHUNK) }})*.nc" -print -delete
+                        find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ PP_CHUNK_A | multiply_duration(CHUNK) }})*.nc" -print -delete
                     fi
     {% endfor %}
 {% else %}

--- a/flow.cylc
+++ b/flow.cylc
@@ -285,7 +285,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             {% if HISTORY_SEGMENT != chunk.chunk_size %}
                 => make-timeseries-regrid-{{ chunk.chunk_size }}<regrid>
             {% endif %}
-            {% if DO_TIMEAVGS %}
+            {% if DO_TIMEAVGS and not chunk.is_partial %}
                 => make-timeavgs-regrid-{{ chunk.chunk_size }}<regrid>
             {% endif %}
         {% endif %}
@@ -298,26 +298,26 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             {% if HISTORY_SEGMENT != chunk.chunk_size %}
                 => make-timeseries-native-{{ chunk.chunk_size }}<native>
             {% endif %}
-            {% if DO_TIMEAVGS %}
+            {% if DO_TIMEAVGS and not chunk.is_partial %}
                 => make-timeavgs-native-{{ chunk.chunk_size }}<native>
             {% endif %}
         {% endif %}
 
         {% if DO_REGRID %}
             {{ "regrid-xy" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'ts', YAML, HISTORY_SEGMENT) }}
-            {% if DO_TIMEAVGS %}
+            {% if DO_TIMEAVGS and not chunk.is_partial %}
                 {{ "regrid-xy" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'av', YAML, HISTORY_SEGMENT) }}
             {% endif %}
         {% endif %}
 
         {% if DO_NATIVE %}
             {{ "native" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'ts', YAML, HISTORY_SEGMENT) }}
-            {% if DO_TIMEAVGS %}
+            {% if DO_TIMEAVGS and not chunk.is_partial %}
                 {{ "native" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'av', YAML, HISTORY_SEGMENT) }}
             {% endif %}
         {% endif %}
 
-        {% if DO_TIMEAVGS %}
+        {% if DO_TIMEAVGS and not chunk.is_partial %}
             remap-pp-components-av-{{ chunk.chunk_size }}<component> => combine-timeavgs-{{ chunk.chunk_size }}<component>
             {% if CLEAN_WORK %}
                 COMBINE-TIMEAVGS-{{ chunk.chunk_size }}:succeed-all => clean-pp-timeavgs-{{ chunk.chunk_size }}
@@ -326,7 +326,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
 
         {% if CLEAN_WORK %}
             REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all => clean-shards-{{ chunk.chunk_size }}
-            {% if DO_TIMEAVGS %}
+            {% if DO_TIMEAVGS and not chunk.is_partial %}
                 REMAP-PP-COMPONENTS-AV-{{ chunk.chunk_size }}:succeed-all => clean-shards-{{ chunk.chunk_size }}
             {% endif %}
         {% endif %}
@@ -338,7 +338,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         {% for segment in chunk.segments %}
             R1/{{ segment }} = """
                 REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}[{{ chunk.cycle_point }}]:succeed-all
-                {% if DO_TIMEAVGS %}
+                {% if DO_TIMEAVGS and not chunk.is_partial %}
                     & REMAP-PP-COMPONENTS-AV-{{ chunk.chunk_size }}[{{ chunk.cycle_point }}]:succeed-all
                 {% endif %}
                 => clean-shards-{{ HISTORY_SEGMENT }}
@@ -823,14 +823,14 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
     [[COMBINE-TIMEAVGS]]
         script = rose task-run --verbose --app-key combine-timeavgs
         [[[environment]]]
-            end = $(cylc cycle-point --print-year)
+            begin = $(cylc cycle-point --print-year)
             outputDir = {{ PP_DIR }}/$CYLC_TASK_PARAM_component/av
     [[COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}]]
         inherit = COMBINE-TIMEAVGS
         [[[environment]]]
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            begin = $(cylc cycle-point --print-year)
             currentChunk = {{ PP_CHUNK_A }}
+            end = $(cylc cycle-point --print-year --offset={{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }})
     [[combine-timeavgs-{{ PP_CHUNK_A }}<component>]]
         inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}, <component>
         [[[environment]]]
@@ -841,8 +841,8 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         inherit = COMBINE-TIMEAVGS
         [[[environment]]]
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            begin = $(cylc cycle-point --print-year)
             currentChunk = {{ PP_CHUNK_B }}
+            end = $(cylc cycle-point --print-year --offset={{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }})
     [[combine-timeavgs-{{ PP_CHUNK_B }}<component>]]
         inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_B }}, <component>
         [[[environment]]]

--- a/flow.cylc
+++ b/flow.cylc
@@ -938,6 +938,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
         script = rose task-run --verbose --app-key make-timeseries
         [[[environment]]]
             fail_ok_components = grid_spec lumip_Lyr lumip_Lyr_crp lumip_Lyr_psl lumip_Lyr_pst
+            pp_stop = {{ PP_STOP }}
 
 {% if DO_NATIVE %}
     [[MAKE-TIMESERIES-NATIVE]]

--- a/flow.cylc
+++ b/flow.cylc
@@ -13,9 +13,6 @@
 {# (Probably, we should use similar mechanisms where sensible, e.g. for shared items among workflows)              #}
 {% set SITE = SITE %}
 
-{# Calculate the number of history segments per a-chunk #}
-{% set HIST_SEGMENTS_PER_CHUNK_A = (PP_CHUNK_A | duration_as('s') / HISTORY_SEGMENT | duration_as('s')) | int %}
-
 {# secs_per_365cal_month #}
 {% set SECS_PER_365CAL_MONTH = (365 / 12 * 24 * 60 * 60) %}
 {# months_per_hist_segment #}
@@ -120,6 +117,9 @@
         # limit the entire workflow to 100 active tasks at once
         [[[default]]]
             limit = 100
+	[[[serial]]]
+	    limit = 1
+	    members = CLEAN
     {# Graph strings are organized by recurrence interval-- when to run the tasks.    #}
     {# Currently, we use 4 intervals: every history-file segment, once (for statics), #}
     {# every chunk-a, and every chunk-b.                                              #}
@@ -261,165 +261,83 @@ combine-statics => clean-pp-statics
 {% endif %}
 """
 
+{% set PP_CHUNKS = [PP_CHUNK_A] %}
 
-        #
-        # Recurrence interval: every CHUNK-A
-        #
-        {# Run the tasks to process CHUNK-A every CHUNK-A, starting after PP_CHUNK_A #}
-        {{ PP_CHUNK_A }} = """
-
-{# Tasks can be split over multiple lines if the subsequent ones begin with =>, &, or |                   #}
-{# The make-timeseries tasks for CHUNK-A depend on all segment processing for the time period succeeding. #}
-{# This Jinja for loop expands to do this.                                                                #}
-{% if DO_REGRID %}
-rename-split-to-pp-regrid<regrid>
-    {% for SEGMENT in range(1, HIST_SEGMENTS_PER_CHUNK_A) %}
-& rename-split-to-pp-regrid<regrid>[{{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }}]
-    {% endfor %}
-    {% if HISTORY_SEGMENT != PP_CHUNK_A %}
-=> make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>
-    {% endif %}
-    {% if DO_TIMEAVGS %}
-=> make-timeavgs-regrid-{{ PP_CHUNK_A }}<regrid>
-    {% endif %}
-{% endif %}
-
-{% if DO_NATIVE %}
-rename-split-to-pp-native<native>
-    {% for SEGMENT in range(1, HIST_SEGMENTS_PER_CHUNK_A) %}
-& rename-split-to-pp-native<native>[{{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }}]
-    {% endfor %}
-    {% if HISTORY_SEGMENT != PP_CHUNK_A %}
-=> make-timeseries-native-{{ PP_CHUNK_A }}<native>
-    {% endif %}
-    {% if DO_TIMEAVGS %}
-=> make-timeavgs-native-{{ PP_CHUNK_A }}<native>
-    {% endif %}
-{% endif %}
-
-{% if DO_REGRID %}
-{{ "regrid-xy" | form_remap_dep('temporal', PP_CHUNK_A, PP_COMPONENTS, 'ts', HISTORY_SEGMENT) }}
-    {% if DO_TIMEAVGS %}
-{{ "regrid-xy" | form_remap_dep('temporal', PP_CHUNK_A, PP_COMPONENTS, 'av', HISTORY_SEGMENT) }}
-    {% endif %}
-{% endif %}
-
-{% if DO_NATIVE %}
-{{ "native" | form_remap_dep('temporal', PP_CHUNK_A, PP_COMPONENTS, 'ts', HISTORY_SEGMENT) }}
-    {% if DO_TIMEAVGS %}
-{{ "native" | form_remap_dep('temporal', PP_CHUNK_A, PP_COMPONENTS, 'av', HISTORY_SEGMENT) }}
-    {% endif %}
-{% endif %}
-
-{% if DO_TIMEAVGS %}
-remap-pp-components-av-{{ PP_CHUNK_A }}<component> => combine-timeavgs-{{ PP_CHUNK_A }}<component>
-    {% if CLEAN_WORK %}
-COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}:succeed-all => clean-pp-timeavgs-{{ PP_CHUNK_A }}
-    {% endif %}
-{% endif %}
-
-# 3 scenarios of CHUNK-A workdir cleaning
-# 1. If secondary chunk is not used, then remove history and chunk-a shards after remapping ts and av
-# 2. If chunk-a equals history segment, then do nothing- these will be removed after chunk-b generation
-# 3. Otherwise, remove prereq history segments and leave the chunk-a shards for chunk-b generation
-{% if CLEAN_WORK %}
-    {% if PP_CHUNK_B is not defined or PP_CHUNK_A != HISTORY_SEGMENT %}
-REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}:succeed-all => clean-shards-{{ HISTORY_SEGMENT }}
-        {% if DO_TIMEAVGS %}
-REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_A }}:succeed-all => clean-shards-{{ HISTORY_SEGMENT }}
-        {% endif %}
-    {% endif %}
-{% endif %}
-
-REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}:succeed-all => data-catalog
-"""
-
-
-#
-# Recurrence interval: every CHUNK-B
-#
-{# If only one pp chunk is used, then skip the CHUNK-B processing. #}
 {% if DO_SECONDARY_PP %}
-        {# Run the tasks to process CHUNK-B every CHUNK-B, starting after CHUNK-B time #}
-        {{ PP_CHUNK_B }} = """
-
-{# The make-timeseries tasks for CHUNK-B depend on all CHUNK-A processing for the time period succeeding. #}
-    {% if DO_REGRID %}
-        {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-rename-split-to-pp-regrid<regrid>
-        {% else %}
-make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>
-        {% endif %}
-        {% for CHUNK in range(1, CHUNK_AS_PER_CHUNK_B) %}
-        {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-& rename-split-to-pp-regrid<regrid>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
-        {% else %}
-& make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
-        {% endif %}
-        {% endfor %}
-=> make-timeseries-regrid-{{ PP_CHUNK_B }}<regrid>
-        {% if DO_TIMEAVGS %}
-=> make-timeavgs-regrid-{{ PP_CHUNK_B }}<regrid>
-        {% endif %}
-    {% endif %}
-
-    {% if DO_NATIVE %}
-        {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-rename-split-to-pp-native<native>
-        {% else %}
-make-timeseries-native-{{ PP_CHUNK_A }}<native>
-        {% endif %}
-        {% for CHUNK in range(1, CHUNK_AS_PER_CHUNK_B) %}
-        {% if HISTORY_SEGMENT == PP_CHUNK_A %}
-& rename-split-to-pp-native<native>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
-        {% else %}
-& make-timeseries-native-{{ PP_CHUNK_A }}<native>[{{ PP_CHUNK_A | multiply_duration(CHUNK)}}]
-        {% endif %}
-        {% endfor %}
-=> make-timeseries-native-{{ PP_CHUNK_B }}<native>
-        {% if DO_TIMEAVGS %}
-=> make-timeavgs-native-{{ PP_CHUNK_B }}<native>
-        {% endif %}
-    {% endif %}
-
-    {% if DO_TIMEAVGS %}
-remap-pp-components-av-{{ PP_CHUNK_B }}<component> => combine-timeavgs-{{ PP_CHUNK_B }}<component>
-        {% if CLEAN_WORK %}
-COMBINE-TIMEAVGS-{{ PP_CHUNK_B }}:succeed-all => clean-pp-timeavgs-{{ PP_CHUNK_B }}
-        {% endif %}
-    {% endif %}
-
-{# Generate the per-component make-timeseries => remap-pp-component tasks using Jinja trigger form_remap_dep #}
-{# Throw validation exception if PP_CHUNK_B is not in rose-app.conf                                          #}
-    {% if DO_REGRID %}
-{{ "regrid-xy" | form_remap_dep('temporal', PP_CHUNK_B, PP_COMPONENTS, 'ts') }}
-        {% if DO_TIMEAVGS %}
-{{ "regrid-xy" | form_remap_dep('temporal', PP_CHUNK_B, PP_COMPONENTS, 'av') }}
-        {% endif %}
-    {% endif %}
-
-    {% if DO_NATIVE %}
-{{ "native" | form_remap_dep('temporal', PP_CHUNK_B, PP_COMPONENTS, 'ts') }}
-        {% if DO_TIMEAVGS %}
-{{ "native" | form_remap_dep('temporal', PP_CHUNK_B, PP_COMPONENTS, 'av') }}
-        {% endif %}
-    {% endif %}
-
-# CHUNK-B work dir cleaning: remove CHUNK-A and CHUNK-B shards after saving the CHUNK-B products
-    {% if CLEAN_WORK %}
-REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_B }}
-        {% if DO_TIMEAVGS %}
-REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_B }}
-        {% endif %}
-REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_A }}
-        {% if DO_TIMEAVGS %}
-REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_A }}
-        {% endif %}
-    {% endif %}
-
-    REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}:succeed-all => data-catalog
-"""
+    {% do PP_CHUNKS.append(PP_CHUNK_B) %}
 {% endif %}
+
+{% for chunk in PP_CHUNKS | iter_chunks(HISTORY_SEGMENT, PP_START, PP_STOP) %}
+    R1/{{ chunk.cycle_point }} = """
+        {% if DO_REGRID %}
+            rename-split-to-pp-regrid<regrid>
+            {% for SEGMENT in chunk.segments[1:] %}
+                & rename-split-to-pp-regrid<regrid>[{{ SEGMENT }}]
+            {% endfor %}
+            {% if HISTORY_SEGMENT != chunk.chunk_size %}
+                => make-timeseries-regrid-{{ chunk.chunk_size }}<regrid>
+            {% endif %}
+            {% if DO_TIMEAVGS %}
+                => make-timeavgs-regrid-{{ chunk.chunk_size }}<regrid>
+            {% endif %}
+        {% endif %}
+
+        {% if DO_NATIVE %}
+            rename-split-to-pp-native<native>
+            {% for SEGMENT in chunk.segments[1:] %}
+                & rename-split-to-pp-native<native>[{{ SEGMENT }}]
+            {% endfor %}
+            {% if HISTORY_SEGMENT != chunk.chunk_size %}
+                => make-timeseries-native-{{ chunk.chunk_size }}<native>
+            {% endif %}
+            {% if DO_TIMEAVGS %}
+                => make-timeavgs-native-{{ chunk.chunk_size }}<native>
+            {% endif %}
+        {% endif %}
+
+        {% if DO_REGRID %}
+            {{ "regrid-xy" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'ts', HISTORY_SEGMENT) }}
+            {% if DO_TIMEAVGS %}
+                {{ "regrid-xy" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'av', HISTORY_SEGMENT) }}
+            {% endif %}
+        {% endif %}
+
+        {% if DO_NATIVE %}
+            {{ "native" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'ts', HISTORY_SEGMENT) }}
+            {% if DO_TIMEAVGS %}
+                {{ "native" | form_remap_dep('temporal', chunk.chunk_size, PP_COMPONENTS, 'av', HISTORY_SEGMENT) }}
+            {% endif %}
+        {% endif %}
+
+        {% if DO_TIMEAVGS %}
+            remap-pp-components-av-{{ chunk.chunk_size }}<component> => combine-timeavgs-{{ chunk.chunk_size }}<component>
+            {% if CLEAN_WORK %}
+                COMBINE-TIMEAVGS-{{ chunk.chunk_size }}:succeed-all => clean-pp-timeavgs-{{ chunk.chunk_size }}
+            {% endif %}
+        {% endif %}
+
+        {% if CLEAN_WORK %}
+            REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all => clean-shards-{{ chunk.chunk_size }}
+            {% if DO_TIMEAVGS %}
+                REMAP-PP-COMPONENTS-AV-{{ chunk.chunk_size }}:succeed-all => clean-shards-{{ chunk.chunk_size }}
+            {% endif %}
+        {% endif %}
+
+        REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all => data-catalog
+    """
+
+    {% if CLEAN_WORK %}
+        {% for segment in chunk.segments %}
+            R1/{{ segment }} = """
+                REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}[{{ chunk.cycle_point }}]:succeed-all
+                {% if DO_TIMEAVGS %}
+                    & REMAP-PP-COMPONENTS-AV-{{ chunk.chunk_size }}[{{ chunk.cycle_point }}]:succeed-all
+                {% endif %}
+                => clean-shards-{{ HISTORY_SEGMENT }}
+            """
+        {% endfor %}
+    {% endif %}
+{% endfor %}
 
 #
 # Recurrence intervals for analysis tasks
@@ -982,7 +900,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
     [[MAKE-TIMESERIES-{{ PP_CHUNK_B }}]]
         [[[environment]]]
             begin = $(cylc cycle-point)
-            inputChunk = {{ PP_CHUNK_A }}
+            inputChunk = {{ HISTORY_SEGMENT }}
             outputChunk = {{ PP_CHUNK_B }}
     {% if DO_NATIVE %}
     [[MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK_B }}]]
@@ -1068,11 +986,6 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
 
     [[CLEAN]]
         pre-script = "set -x"
-        # find commands can fail if the files change underneath, even if the change
-        # is not the files that are desired. e.g. we are cleaning year 2000 and year 1999
-        # was removed/cleaned half-way through. The find will fail.
-        # It would be best to ignore the missing files, but retrying will help.
-        execution retry delays = PT5M, PT10M, PT15M
 
     [[clean-history-native]]
         inherit = CLEAN
@@ -1117,9 +1030,7 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/ts/native/*/*/{{ HISTORY_SEGMENT }} $CYLC_WORKFLOW_SHARE_DIR/shards/ts/regrid-xy/*/*/*/{{ HISTORY_SEGMENT }}"
             for dir in $dirs; do
                 if ls $dir; then
-{% for SEGMENT in range(0, HIST_SEGMENTS_PER_CHUNK_A) %}
-                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ HISTORY_SEGMENT | multiply_duration(SEGMENT) }})*.nc" -print -delete
-{% endfor %}
+                    find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
                 fi
             done
         """
@@ -1130,21 +1041,11 @@ REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}:succeed-all => clean-shards-{{ PP_CHUNK_
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_A }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_A }}"
             for dir in $dirs; do
                 if ls $dir; then
-{% if DO_SECONDARY_PP %}
-    {% for CHUNK in range(0, CHUNK_AS_PER_CHUNK_B) %}
-                    if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY   --offset={{ PP_CHUNK_A | multiply_duration(CHUNK) }})*.nc" -print -delete
-                    else
-                        find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY --offset={{ PP_CHUNK_A | multiply_duration(CHUNK) }})*.nc" -print -delete
-                    fi
-    {% endfor %}
-{% else %}
                     if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
                         find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
                     else
                         find $dir -type f -name "*.*-$(cylc cycle-point --template CCYY)*.nc" -print -delete
                     fi
-{% endif %}
                 fi
             done
         """


### PR DESCRIPTION
* Perform `CHUNK_A` and `CHUNK_B` tasks on first cycle point of the chunk rather than the last.
* Add `iter_chunks` Jinja filter to iterate over PP chunks.
* Add tasks associated with PP chunks to the graph using `iter_chunks`.
* Modify `make-timeseries` script to support remainder chunks
* Run history segment cleaning tasks on every cycle point, rather than once per chunk.
* Add a queue for cleaning jobs to ensure that they run serially.

The purpose of these changes is to support remainder PP chunks.