### PR TITLE
replacing split-netcdf with split-netcdf-python

### DIFF
--- a/app/split-netcdf-python/bin/split-netcdf
+++ b/app/split-netcdf-python/bin/split-netcdf
@@ -1,4 +1,4 @@
-#!/bin/python
+ #!/bin/python
 
 # Split NetCDF files by variable
 #
@@ -8,9 +8,10 @@
 # Output format: date.component.var(.tileX).nc
 
 import os
+from os import path
 import glob
 import subprocess
-import cdo
+#import cdo
 import sys
 from pathlib import Path
 
@@ -28,7 +29,7 @@ print("    date: "+date)
 print("    component: "+component)
 print("    use subdirs: "+use_subdirs)
 print("Utilities:")
-type(cdo)
+#type(cdo)
 
 #Verify input directory exists and is a directory
 if inputDir == "":
@@ -43,7 +44,8 @@ if outputDir == "":
 #Find files to split
 #extend globbing used to find both tiled and non-tiled files
 curr_dir = os.getcwd()
-os.chdir("curr_dir/inputDir")
+workdir = os.path.abspath(inputDir)
+os.chdir(workdir)
 
 #If in sub-dir mode, process the sub-directories instead of the main one
 if use_subdirs:

--- a/app/split-netcdf/bin/split-netcdf
+++ b/app/split-netcdf/bin/split-netcdf
@@ -46,7 +46,7 @@ cd $inputDir
 shopt -s extglob
 
 # If in sub-dir mode, process the sub-directories instead of the main one
-if [[ $use_subdirs ]]; then
+if [[ $use_subdirs == 0 ]]; then
     for subdir in $(ls); do
         pushd $subdir
         files=$(echo *.$component?(.tile?).nc)
@@ -108,6 +108,7 @@ if [[ $use_subdirs ]]; then
     done
 else
     files=$(echo *.$component?(.tile?).nc)
+    echo *.?(.tile?).nc
 
     # Exit if no input files are found
     if [[ $files =~ \* ]]; then


### PR DESCRIPTION
[x] do they do the same things for the subdirs case?
[ ] do they do the same things for the no subdirs case?
   - no - split-netcdf switches on present/missing and split-netcdf-python switches on true/false. This turns into the same behavior for the subdirs case, but for the no subdirs case split-netcdf-python switches to the subdirs case all the time. 
   - The solution here is going to require flow.cylc to set true/false for the use_subdirs parameter. Generally the regridding postprocessing jobs are going to use subdirs but the native postprocessing jobs will not.

See the conversation with Dana on 2025-03-21 for more information