### PR TITLE
Support heavier regridding use case

### DIFF
--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -101,7 +101,7 @@ def freq_to_legacy(iso_dura):
         freq_legacy = '2hr'
     elif iso_dura=='PT1H':
         freq_legacy = 'hourly'
-    elif iso_dura=='PT30M' or iso_dura=='PT0.5H':
+    elif iso_dura in ['PT30M', 'PT0.5H']:
         freq_legacy = '30min'
     else:
         raise ValueError(f"Could not convert ISO duration '{iso_dura}'")

--- a/app/rename-split-to-pp/bin/rename-split-to-pp
+++ b/app/rename-split-to-pp/bin/rename-split-to-pp
@@ -92,11 +92,17 @@ function process_files {
 
         # chunksize is the duration of the file
         chunk=$(isodatetime $date1 $(isodatetime $date2 --offset=$freq))
-        # if the duration is a 365 or 366 days, count it as a year
+        # Adjustments
+        # 1. if the duration is a 365 or 366 days, count it as a year
+        # 2. if the duration is ~30days, count it as a month
+        # 3. if the duration is 180-185, count it as 6 months
         if [[ $chunk =~ ^P([0-9]+)D$ ]]; then
             if (( ${BASH_REMATCH[1]} > 27 )) && (( ${BASH_REMATCH[1]} < 32 )); then
                 echo "NOTE: Promoting $chunk to P1M"
                 chunk=P1M
+            elif (( ${BASH_REMATCH[1]} > 179)) && (( ${BASH_REMATCH[1]} < 186 )); then
+                echo "NOTE: Promoting $chunk to P6M"
+                chunk=P6M
             else
                 years_int=$(perl -e "print int(${BASH_REMATCH[1]} / 365)")
                 years_frac=$(perl -e "print ${BASH_REMATCH[1]} / 365 - $years_int")

--- a/flow.cylc
+++ b/flow.cylc
@@ -1036,7 +1036,9 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/ts/native/*/*/{{ HISTORY_SEGMENT }} $CYLC_WORKFLOW_SHARE_DIR/shards/ts/regrid-xy/*/*/*/{{ HISTORY_SEGMENT }}"
             for dir in $dirs; do
-                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                if [[ -d $dir ]]; then
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                fi
             done
         """
 
@@ -1045,10 +1047,14 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_A }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_A }}"
             for dir in $dirs; do
-                if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
+                if [[ -d $dir ]]; then
+                    if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
+                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
+                    else
+                        find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                    fi
                 else
-                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                    echo "Skipping '$dir' as it does not exist"
                 fi
             done
         """
@@ -1059,7 +1065,11 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = """
             dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_B }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_B }}"
             for dir in $dirs; do
-                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                if [[ -d $dir ]]; then
+                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                else
+                    echo "Skipping '$dir' as it does not exist"
+                fi
             done
         """
 {% endif %}

--- a/flow.cylc
+++ b/flow.cylc
@@ -1038,6 +1038,8 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             for dir in $dirs; do
                 if [[ -d $dir ]]; then
                     find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                else
+                    echo "Skipping '$dir' as it does not exist"
                 fi
             done
         """

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -98,6 +98,7 @@
 
 {% if DO_REGRID %}
     [[REGRID-XY]]
+        execution time limit = P1D
         pre-script = """
             # the conda activate below brings in an old fre-nctools
             # that is conda installable. we need an updated


### PR DESCRIPTION
A user postprocessing large history files (c96, daily, 50 vertical levels, many variables, 400 GB per tile) had trouble with Bronx frepp jobs timing out.

Converting the user's configurations to yaml and using FRE 2025 worked better, with these adjustments

1. Increase wallclock for fregrid jobs from 4 hours (standard default for all jobs) to 24 hours
2. When placing history files into shard directory (organized by frequency and chunksize), 6 months was getting interpreted as days, but the configuration is expecting "P6M". So an update to `rename-split` was needed to upgrade days ~6 months to "P6M proper
3. Not related to regridding exactly, but the cleaning tasks expected some native output and fail if there are none.