### PR TITLE
Run analysis tasks on the correct cycle points (and other changes)

### DIFF
--- a/Jinja2Filters/get_analysis_info.py
+++ b/Jinja2Filters/get_analysis_info.py
@@ -243,7 +243,15 @@ class AnalysisScript(object):
         return graph
 
     def definition(self, chunk, pp_dir):
-        """Form the task definition string."""
+        """Generate the cylc task definition string for the analysis script.
+
+        Args:
+            chunk: Post-processing chunk size for this analysis script
+            pp_dir: postprocessing directory
+
+        Returns:
+            Cylc task definition string for this analysis script
+        """
         if self.switch == False:
             return ""
 
@@ -570,7 +578,7 @@ def task_definitions(yaml_, experiment_components, experiment_start, experiment_
         experiment_start: Date that the experiment starts at.
         experiment_stop: Date that the experiment stops at.
         chunks: List of ISO8601 durations used by the workflow.
-        pp_dir: postproceessing directory
+        pp_dir: postprocessing directory
 
     Returns:
         String containing the task defintions.

--- a/Jinja2Filters/get_analysis_info.py
+++ b/Jinja2Filters/get_analysis_info.py
@@ -259,14 +259,11 @@ class AnalysisScript(object):
         # ts and av distinction
         if self.product == "ts":
             in_data_dir = Path(pp_dir) / self.components[0] / self.product / frequency / bronx_chunk
-            pre_script = "pre-script = rose task-run --verbose --app-key data-catalog\n"
         else:
             in_data_dir = Path(pp_dir) / self.components[0] / self.product / f"{frequency}_{bronx_chunk}"
-            pre_script = ""
 
         legacy_analysis_str = f"""
     [[analysis-{self.name}]]
-        {pre_script}
         script = '''
 # First, sed-replace the template vars and create a runnable analysis script from the template.
 # actually, just sed-replace the undercase environment variables
@@ -322,7 +319,6 @@ $scriptOut {self.legacy_script_args}
 
         new_analysis_str = f"""
     [[analysis-{self.name}]]
-        {pre_script}
         script = '''
 fre analysis run \
     --name              freanalysis_{self.name} \

--- a/app/data-catalog/bin/data-catalog
+++ b/app/data-catalog/bin/data-catalog
@@ -11,21 +11,27 @@ echo "    PP_DIR: $PP_DIR"
 echo Utilities:
 type fre
 
-TIMESTAMP_FILE=$CYLC_WORKFLOW_RUN_DIR/.catalog
+CATALOG_CSV=$PP_DIR/catalog.csv
 
 function fre_catalog_builder () {
-    touch $TIMESTAMP_FILE
+    # Get a timestamp immediately before `fre catalog builder` is run. Assign
+    # this timestamp to catalog.csv afterward, to guarantee that the catalog
+    # will be rebuilt in the edge case where files are being added to the PP
+    # directory while `fre catalog builder` is running.
+
+    TIMESTAMP=`date +%T.%N`
     fre catalog builder $* $PP_DIR $PP_DIR/catalog
+    touch -d $TIMESTAMP $CATALOG_CSV
 }
 
-if [[ ! -f $TIMESTAMP_FILE ]]
+if [[ ! -f $CATALOG_CSV ]]
 then
-    echo "No timestamp file was found: Generating initial catalog"
+    echo "No existing catalog was found: Generating initial catalog"
     fre_catalog_builder
-elif [[ `find $PP_DIR -mindepth 2 -type f -newer $TIMESTAMP_FILE -print -quit` ]]
+elif [[ `find $PP_DIR -mindepth 2 -type f -newer $CATALOG_CSV -print -quit` ]]
 then
     echo "Catalog is stale: Regenerating catalog"
     fre_catalog_builder --overwrite
 else
-    echo "Catalog is up to date"
+    echo "Catalog is up to date: Doing nothing"
 fi

--- a/app/data-catalog/bin/data-catalog
+++ b/app/data-catalog/bin/data-catalog
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+#
+# Run `fre catalog builder` to generate or regenerate the PP catalog
+#
+
+echo Arguments:
+echo "    PP_DIR: $PP_DIR"
+echo Utilities:
+type fre
+
+TIMESTAMP_FILE=$CYLC_WORKFLOW_RUN_DIR/.catalog
+
+function fre_catalog_builder () {
+    touch $TIMESTAMP_FILE
+    fre catalog builder $* $PP_DIR $PP_DIR/catalog
+}
+
+if [[ ! -f $TIMESTAMP_FILE ]]
+then
+    echo "No timestamp file was found: Generating initial catalog"
+    fre_catalog_builder
+elif [[ `find $PP_DIR -mindepth 2 -type f -newer $TIMESTAMP_FILE -print -quit` ]]
+then
+    echo "Catalog is stale: Regenerating catalog"
+    fre_catalog_builder --overwrite
+else
+    echo "Catalog is up to date"
+fi

--- a/bin/data-catalog
+++ b/bin/data-catalog
@@ -3,20 +3,22 @@ set -euo pipefail
 set -x
 
 #
-# Run `fre catalog builder` to generate or regenerate the PP catalog
+# Run `fre catalog builder` to generate or regenerate the PP catalog.
 #
 
 echo Arguments:
 echo "    PP_DIR: $PP_DIR"
+echo "    CYLC_TASK_LOG_DIR: $CYLC_TASK_LOG_DIR"
 echo Utilities:
 type fre
 
 CATALOG_CSV=$PP_DIR/catalog.csv
+JOB_SCRIPT=$CYLC_TASK_LOG_DIR/job
 
 function fre_catalog_builder () {
     # Get a timestamp immediately before `fre catalog builder` is run. Assign
     # this timestamp to catalog.csv afterward, to guarantee that the catalog
-    # will be rebuilt in the edge case where files are being added to the PP
+    # will be rebuilt in the edge case where files are added to the PP directory
     # directory while `fre catalog builder` is running.
 
     TIMESTAMP=`date +%T.%N`
@@ -24,11 +26,18 @@ function fre_catalog_builder () {
     touch -d $TIMESTAMP $CATALOG_CSV
 }
 
+# There are two cases for which the catalog builder should be run:
+# - If there's no existing catalog.csv file
+# - If the PP directory contains files which are newer than the existing
+#   catalog.csv, excluding any files which are newer than the current task's job
+#   script. This ensures that the catalog is up to date as of the time this task
+#   was scheduled.
+
 if [[ ! -f $CATALOG_CSV ]]
 then
     echo "No existing catalog was found: Generating initial catalog"
     fre_catalog_builder
-elif [[ `find $PP_DIR -mindepth 2 -type f -newer $CATALOG_CSV -print -quit` ]]
+elif [[ `find $PP_DIR -mindepth 2 -type f -newer $CATALOG_CSV ! -newer $JOB_SCRIPT -print -quit` ]]
 then
     echo "Catalog is stale: Regenerating catalog"
     fre_catalog_builder --overwrite

--- a/bin/data-catalog
+++ b/bin/data-catalog
@@ -19,7 +19,7 @@ function fre_catalog_builder () {
     # Get a timestamp immediately before `fre catalog builder` is run. Assign
     # this timestamp to catalog.csv afterward, to guarantee that the catalog
     # will be rebuilt in the edge case where files are added to the PP directory
-    # directory while `fre catalog builder` is running.
+    # while `fre catalog builder` is running.
 
     TIMESTAMP=`date +%T.%N`
     fre catalog builder $* $PP_DIR $PP_DIR/catalog

--- a/flow.cylc
+++ b/flow.cylc
@@ -111,12 +111,12 @@
         # or data-catalog task to run at once, as they can fail if run in parallel.
         [[[default]]]
             limit = 100
-	[[[clean]]]
-	    limit = 1
-	    members = CLEAN
-	[[[data-catalog]]]
-	    limit = 1
-	    members = DATA-CATALOG
+        [[[clean]]]
+            limit = 1
+            members = CLEAN
+        [[[data-catalog]]]
+            limit = 1
+            members = DATA-CATALOG
     {# Graph strings are organized by recurrence interval-- when to run the tasks.    #}
     {# Currently, we use 4 intervals: every history-file segment, once (for statics), #}
     {# every chunk-a, and every chunk-b.                                              #}

--- a/flow.cylc
+++ b/flow.cylc
@@ -774,11 +774,6 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
     [[data-catalog-final]]
         inherit = DATA-CATALOG
 
-    {% for PP_CHUNK in PP_CHUNKS %}
-        [[data-catalog-{{ PP_CHUNK }}]]
-            inherit = DATA-CATALOG
-    {% endfor %}
-
 {% if DO_TIMEAVGS %}
     [[COMBINE-TIMEAVGS]]
         script = rose task-run --verbose --app-key combine-timeavgs

--- a/flow.cylc
+++ b/flow.cylc
@@ -50,9 +50,6 @@
     UTC mode = True
 
     [[events]]
-        # Run the data-catalog script on shutdown.
-        shutdown handlers = rose task-run --verbose --app-key data-catalog
-
         # When the stall timeout is reached, a stalled workflow will exit
         # and remove the /xtmp working directory.
         stall timeout = P1W
@@ -111,12 +108,15 @@
     runahead limit = P20
     [[queues]]
         # Limit the entire workflow to 100 active tasks. Only allow a single cleaning
-        # task to run at once, as they can fail if run in parallel.
+        # or data-catalog task to run at once, as they can fail if run in parallel.
         [[[default]]]
             limit = 100
 	[[[clean]]]
 	    limit = 1
 	    members = CLEAN
+	[[[data-catalog]]]
+	    limit = 1
+	    members = DATA-CATALOG
     {# Graph strings are organized by recurrence interval-- when to run the tasks.    #}
     {# Currently, we use 4 intervals: every history-file segment, once (for statics), #}
     {# every chunk-a, and every chunk-b.                                              #}
@@ -314,6 +314,8 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
 
         REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all
     """
+
+    R1/$ = REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}[{{ chunk.cycle_point }}]:succeed-all => data-catalog-final
 
     {% if CLEAN_WORK %}
         {% for segment in chunk.segments %}
@@ -764,6 +766,16 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             product = static
             dirTSWorkaround = ""
 {% endif %}
+
+    [[DATA-CATALOG]]
+        script = rose task-run --verbose --app-key data-catalog
+    [[data-catalog-final]]
+        inherit = DATA-CATALOG
+
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[data-catalog-{{ PP_CHUNK }}]]
+            inherit = DATA-CATALOG
+    {% endfor %}
 
 {% if DO_TIMEAVGS %}
     [[COMBINE-TIMEAVGS]]

--- a/flow.cylc
+++ b/flow.cylc
@@ -13,23 +13,10 @@
 {# (Probably, we should use similar mechanisms where sensible, e.g. for shared items among workflows)              #}
 {% set SITE = SITE %}
 
-{# secs_per_365cal_month #}
-{% set SECS_PER_365CAL_MONTH = (365 / 12 * 24 * 60 * 60) %}
-{# months_per_hist_segment #}
-{% set MOS_PER_HIST_SEGMENT = (HISTORY_SEGMENT | duration_as('s') / SECS_PER_365CAL_MONTH) | int %}
-{# months_per_chunk_a #}
-{% set MOS_PER_CHUNK_A = (PP_CHUNK_A | duration_as('s') / SECS_PER_365CAL_MONTH) | int %}
+{% set PP_CHUNKS = [PP_CHUNK_A] %}
 
-
-{# Calculate the number of a-chunks per b-chunk (if desired) #}
-{% set DO_SECONDARY_PP = False %}
 {% if PP_CHUNK_B is defined and PP_CHUNK_B != PP_CHUNK_A %}
-    {% set CHUNK_AS_PER_CHUNK_B = (PP_CHUNK_B | duration_as('s') / PP_CHUNK_A | duration_as('s')) | int %}
-    {% set DO_SECONDARY_PP = True %}
-    {# months_per_chunk_b #}
-	{% set MOS_PER_CHUNK_B = (PP_CHUNK_B | duration_as('s') / SECS_PER_365CAL_MONTH) | int %}
-{% else %}
-    {% set MOS_PER_CHUNK_B = -1 %}
+    {% do PP_CHUNKS.append(PP_CHUNK_B) %}
 {% endif %}
 
 {# Set ANALYSIS_START and ANALYSIS_STOP if they do not exist #}
@@ -62,9 +49,12 @@
     install = app/*, bin/*, etc/*, lib/*
     UTC mode = True
 
-    # When the stall timeout is reached, a stalled workflow will exit
-    # and remove the /xtmp working directory.
     [[events]]
+        # Run the data-catalog script on shutdown.
+        shutdown handlers = rose task-run --verbose --app-key data-catalog
+
+        # When the stall timeout is reached, a stalled workflow will exit
+        # and remove the /xtmp working directory.
         stall timeout = P1W
 
 [task parameters]
@@ -120,10 +110,11 @@
     # stage-history tasks first, possibly filling /xtmp before the clean tasks run.
     runahead limit = P20
     [[queues]]
-        # limit the entire workflow to 100 active tasks at once
+        # Limit the entire workflow to 100 active tasks. Only allow a single cleaning
+        # task to run at once, as they can fail if run in parallel.
         [[[default]]]
             limit = 100
-	[[[serial]]]
+	[[[clean]]]
 	    limit = 1
 	    members = CLEAN
     {# Graph strings are organized by recurrence interval-- when to run the tasks.    #}
@@ -131,11 +122,7 @@
     {# every chunk-a, and every chunk-b.                                              #}
     [[graph]]
 {% if DO_ANALYSIS_ONLY %}
-    {% if DO_SECONDARY_PP %}
-{{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, PP_CHUNK_B, DO_ANALYSIS_ONLY) }}
-    {% else %}
-{{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, None, DO_ANALYSIS_ONLY) }}
-    {% endif %}
+    {{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNKS, DO_ANALYSIS_ONLY) }}
 {% else %}
         #
         # Recurrence interval: every history-file segment
@@ -269,12 +256,6 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
 
 """
 
-{% set PP_CHUNKS = [PP_CHUNK_A] %}
-
-{% if DO_SECONDARY_PP %}
-    {% do PP_CHUNKS.append(PP_CHUNK_B) %}
-{% endif %}
-
 {% for chunk in PP_CHUNKS | iter_chunks(HISTORY_SEGMENT, PP_START, PP_STOP) %}
     R1/{{ chunk.cycle_point }} = """
         {% if DO_REGRID %}
@@ -331,7 +312,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             {% endif %}
         {% endif %}
 
-        REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all => data-catalog
+        REMAP-PP-COMPONENTS-TS-{{ chunk.chunk_size }}:succeed-all
     """
 
     {% if CLEAN_WORK %}
@@ -351,11 +332,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
 # Recurrence intervals for analysis tasks
 #
     {% if DO_ANALYSIS %}
-        {% if DO_SECONDARY_PP %}
-{{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, PP_CHUNK_B, DO_ANALYSIS_ONLY) }}
-        {% else %}
-{{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, None, DO_ANALYSIS_ONLY) }}
-        {% endif %}
+        {{ YAML | get_analysis_info('task-graph', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNKS, DO_ANALYSIS_ONLY) }}
     {% endif %}
 
 {% endif %}
@@ -510,38 +487,23 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             component = $CYLC_TASK_PARAM_regrid
             use_subdirs = 1
     {% endif %}
-    [[MAKE-TIMEAVGS-{{ PP_CHUNK_A }}]]
-        [[[environment]]]
-            interval = {{ PP_CHUNK_A }}
-    {% if DO_NATIVE %}
-    [[MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK_A }}]]
-        inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-NATIVE, MAKE-TIMEAVGS-{{ PP_CHUNK_A }}
-    [[make-timeavgs-native-{{ PP_CHUNK_A }}<native>]]
-        inherit = MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK_A }}, <native>
-    {% endif %}
-    {% if DO_REGRID %}
-    [[MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK_A }}]]
-        inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-REGRID, MAKE-TIMEAVGS-{{ PP_CHUNK_A }}
-    [[make-timeavgs-regrid-{{ PP_CHUNK_A }}<regrid>]]
-        inherit = MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK_A }}, <regrid>
-    {% endif %}
-    {% if DO_SECONDARY_PP %}
-    [[MAKE-TIMEAVGS-{{ PP_CHUNK_B }}]]
-        [[[environment]]]
-            interval = {{ PP_CHUNK_B }}
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[MAKE-TIMEAVGS-{{ PP_CHUNK }}]]
+            [[[environment]]]
+                interval = {{ PP_CHUNK }}
         {% if DO_NATIVE %}
-    [[MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK_B }}]]
-        inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-NATIVE, MAKE-TIMEAVGS-{{ PP_CHUNK_B }}
-    [[make-timeavgs-native-{{ PP_CHUNK_B }}<native>]]
-        inherit = MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK_B }}, <native>
+            [[MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK }}]]
+                inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-NATIVE, MAKE-TIMEAVGS-{{ PP_CHUNK }}
+            [[make-timeavgs-native-{{ PP_CHUNK }}<native>]]
+                inherit = MAKE-TIMEAVGS-NATIVE-{{ PP_CHUNK }}, <native>
         {% endif %}
         {% if DO_REGRID %}
-    [[MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK_B }}]]
-        inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-REGRID, MAKE-TIMEAVGS-{{ PP_CHUNK_B }}
-    [[make-timeavgs-regrid-{{ PP_CHUNK_B }}<regrid>]]
-        inherit = MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK_B }}, <regrid>
+            [[MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK }}]]
+                inherit = MAKE-TIMEAVGS, MAKE-TIMEAVGS-REGRID, MAKE-TIMEAVGS-{{ PP_CHUNK }}
+            [[make-timeavgs-regrid-{{ PP_CHUNK }}<regrid>]]
+                inherit = MAKE-TIMEAVGS-REGRID-{{ PP_CHUNK }}, <regrid>
         {% endif %}
-    {% endif %}
+    {% endfor %}
 {% endif %}
 
 {% if DO_REFINEDIAG or DO_PREANALYSIS %}
@@ -764,24 +726,15 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             outputDir = {{ PP_DIR }}
             product = ts
             dirTSWorkaround = 1
-    [[REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}]]
-        inherit = REMAP-PP-COMPONENTS-TS
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            currentChunk = {{ PP_CHUNK_A }}
-    [[remap-pp-components-ts-{{ PP_CHUNK_A }}<component>]]
-        inherit = REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_A }}, <component>
-
-{% if DO_SECONDARY_PP %}
-    [[REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}]]
-        inherit = REMAP-PP-COMPONENTS-TS
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            currentChunk = {{ PP_CHUNK_B }}
-    [[remap-pp-components-ts-{{ PP_CHUNK_B }}<component>]]
-        inherit = REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK_B }}, <component>
-
-{% endif %}
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK }}]]
+            inherit = REMAP-PP-COMPONENTS-TS
+            [[[environment]]]
+                begin = $(cylc cycle-point)
+                currentChunk = {{ PP_CHUNK }}
+        [[remap-pp-components-ts-{{ PP_CHUNK }}<component>]]
+            inherit = REMAP-PP-COMPONENTS-TS-{{ PP_CHUNK }}, <component>
+    {% endfor %}
 
     [[REMAP-PP-COMPONENTS-AV]]
         inherit = REMAP-PP-COMPONENTS
@@ -789,23 +742,16 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             inputDir = $CYLC_WORKFLOW_SHARE_DIR/shards/av
             outputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
             product = av
-    [[REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_A }}]]
-        inherit = REMAP-PP-COMPONENTS-AV
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            currentChunk = {{ PP_CHUNK_A }}
-    [[remap-pp-components-av-{{ PP_CHUNK_A }}<component>]]
-        inherit = REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_A }}, <component>
 
-{% if DO_SECONDARY_PP %}
-    [[REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}]]
-        inherit = REMAP-PP-COMPONENTS-AV
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            currentChunk = {{ PP_CHUNK_B }}
-    [[remap-pp-components-av-{{ PP_CHUNK_B }}<component>]]
-        inherit = REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK_B }}, <component>
-{% endif %}
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK }}]]
+            inherit = REMAP-PP-COMPONENTS-AV
+            [[[environment]]]
+                begin = $(cylc cycle-point)
+                currentChunk = {{ PP_CHUNK }}
+        [[remap-pp-components-av-{{ PP_CHUNK }}<component>]]
+            inherit = REMAP-PP-COMPONENTS-AV-{{ PP_CHUNK }}, <component>
+    {% endfor %}
 
 {% if DO_REGRID_STATIC or DO_NATIVE_STATIC %}
     [[remap-pp-components-static]]
@@ -825,42 +771,20 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         [[[environment]]]
             begin = $(cylc cycle-point --print-year)
             outputDir = {{ PP_DIR }}/$CYLC_TASK_PARAM_component/av
-    [[COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}]]
-        inherit = COMBINE-TIMEAVGS
-        [[[environment]]]
-            inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            currentChunk = {{ PP_CHUNK_A }}
-            end = $(cylc cycle-point --print-year --offset={{ PP_CHUNK_A | subtract_durations(HISTORY_SEGMENT) }})
-    [[combine-timeavgs-{{ PP_CHUNK_A }}<component>]]
-        inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_A }}, <component>
-        [[[environment]]]
-            component = $CYLC_TASK_PARAM_component
 
-    {% if DO_SECONDARY_PP %}
-    [[COMBINE-TIMEAVGS-{{ PP_CHUNK_B }}]]
-        inherit = COMBINE-TIMEAVGS
-        [[[environment]]]
-            inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
-            currentChunk = {{ PP_CHUNK_B }}
-            end = $(cylc cycle-point --print-year --offset={{ PP_CHUNK_B | subtract_durations(HISTORY_SEGMENT) }})
-    [[combine-timeavgs-{{ PP_CHUNK_B }}<component>]]
-        inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK_B }}, <component>
-        [[[environment]]]
-            component = $CYLC_TASK_PARAM_component
-
-    {% endif %}
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[COMBINE-TIMEAVGS-{{ PP_CHUNK }}]]
+            inherit = COMBINE-TIMEAVGS
+            [[[environment]]]
+                inputDir = $CYLC_WORKFLOW_SHARE_DIR/pp/av
+                currentChunk = {{ PP_CHUNK }}
+                end = $(cylc cycle-point --print-year --offset={{ PP_CHUNK | subtract_durations(HISTORY_SEGMENT) }})
+        [[combine-timeavgs-{{ PP_CHUNK }}<component>]]
+            inherit = COMBINE-TIMEAVGS-{{ PP_CHUNK }}, <component>
+            [[[environment]]]
+                component = $CYLC_TASK_PARAM_component
+    {% endfor %}
 {% endif %}
-
-    [[data-catalog]]
-        script = """
-        fre catalog builder --overwrite $ppdir $ppdir/catalog
-        """
-        # when many data catalog jobs run simultaneously, they can fail
-        # this is not a good solution here
-        execution retry delays = PT5M, PT10M, PT15M
-        [[[environment]]]
-          ppdir = {{ PP_DIR }}
-
 
     [[MAKE-TIMESERIES]]
         pre-script = mkdir -p $outputDir
@@ -886,44 +810,25 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             use_subdirs = 1
 {% endif %}
 
-    [[MAKE-TIMESERIES-{{ PP_CHUNK_A }}]]
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            inputChunk = {{ HISTORY_SEGMENT }}
-            outputChunk = {{ PP_CHUNK_A }}
-{% if DO_NATIVE %}
-    [[MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK_A }}]]
-        inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-NATIVE, MAKE-TIMESERIES-{{ PP_CHUNK_A }}
-    [[make-timeseries-native-{{ PP_CHUNK_A }}<native>]]
-        inherit = MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK_A }}, <native>
-{% endif %}
-{% if DO_REGRID %}
-    [[MAKE-TIMESERIES-REGRID-{{ PP_CHUNK_A }}]]
-        inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-REGRID, MAKE-TIMESERIES-{{ PP_CHUNK_A }}
-    [[make-timeseries-regrid-{{ PP_CHUNK_A }}<regrid>]]
-        inherit = MAKE-TIMESERIES-REGRID-{{ PP_CHUNK_A }}, <regrid>
-{% endif %}
-
-{% if DO_SECONDARY_PP %}
-    [[MAKE-TIMESERIES-{{ PP_CHUNK_B }}]]
-        [[[environment]]]
-            begin = $(cylc cycle-point)
-            inputChunk = {{ HISTORY_SEGMENT }}
-            outputChunk = {{ PP_CHUNK_B }}
-    {% if DO_NATIVE %}
-    [[MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK_B }}]]
-        inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-NATIVE, MAKE-TIMESERIES-{{ PP_CHUNK_B }}
-    [[make-timeseries-native-{{ PP_CHUNK_B }}<native>]]
-        inherit = MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK_B }}, <native>
-    {% endif %}
-
-    {% if DO_REGRID %}
-    [[MAKE-TIMESERIES-REGRID-{{ PP_CHUNK_B }}]]
-        inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-REGRID, MAKE-TIMESERIES-{{ PP_CHUNK_B }}
-    [[make-timeseries-regrid-{{ PP_CHUNK_B }}<regrid>]]
-        inherit = MAKE-TIMESERIES-REGRID-{{ PP_CHUNK_B }}, <regrid>
-    {% endif %}
-{% endif %}
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[MAKE-TIMESERIES-{{ PP_CHUNK }}]]
+            [[[environment]]]
+                begin = $(cylc cycle-point)
+                inputChunk = {{ HISTORY_SEGMENT }}
+                outputChunk = {{ PP_CHUNK }}
+        {% if DO_NATIVE %}
+            [[MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK }}]]
+                inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-NATIVE, MAKE-TIMESERIES-{{ PP_CHUNK }}
+            [[make-timeseries-native-{{ PP_CHUNK }}<native>]]
+                inherit = MAKE-TIMESERIES-NATIVE-{{ PP_CHUNK }}, <native>
+        {% endif %}
+        {% if DO_REGRID %}
+            [[MAKE-TIMESERIES-REGRID-{{ PP_CHUNK }}]]
+                inherit = MAKE-TIMESERIES, MAKE-TIMESERIES-REGRID, MAKE-TIMESERIES-{{ PP_CHUNK }}
+            [[make-timeseries-regrid-{{ PP_CHUNK }}<regrid>]]
+                inherit = MAKE-TIMESERIES-REGRID-{{ PP_CHUNK }}, <regrid>
+        {% endif %}
+    {% endfor %}
 
 {% if DO_REGRID %}
     [[REGRID-XY]]
@@ -986,11 +891,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             # new template vars
             catalog = {{ PP_DIR }}/catalog.json
             experiment_yaml = $CYLC_WORKFLOW_RUN_DIR/{{ EXPERIMENT }}.yaml
-    {% if DO_SECONDARY_PP %}
-{{ YAML | get_analysis_info('task-definitions', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, PP_CHUNK_B, False ) }}
-    {% else %}
-{{ YAML | get_analysis_info('task-definitions', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNK_A, None, False ) }}
-    {% endif %}
+    {{ YAML | get_analysis_info('task-definitions', PP_COMPONENTS, PP_DIR, PP_START, PP_STOP, PP_CHUNKS, False ) }}
 {% endif %}
 
     [[CLEAN]]
@@ -1044,63 +945,37 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
             done
         """
 
-    [[clean-shards-{{ PP_CHUNK_A }}]]
-        inherit = CLEAN
-        script = """
-            dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_A }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_A }}"
-            for dir in $dirs; do
-                if [[ -d $dir ]]; then
-                    if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
+    {% for PP_CHUNK in PP_CHUNKS %}
+        [[clean-shards-{{ PP_CHUNK }}]]
+            inherit = CLEAN
+            script = """
+                dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK }}"
+                for dir in $dirs; do
+                    if [[ -d $dir ]]; then
+                        if [[ {{ PP_CHUNK }} == P1Y ]]; then
+                            find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
+                        else
+                            find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
+                        fi
+                    else
+                        echo "Skipping '$dir' as it does not exist"
+                    fi
+                done
+            """
+
+        [[clean-pp-timeavgs-{{ PP_CHUNK }}]]
+            inherit = CLEAN
+            script = """
+                dirs=$CYLC_WORKFLOW_SHARE_DIR/pp/av/*/*/{{ PP_CHUNK }}
+                for dir in $dirs; do
+                    if [[ {{ PP_CHUNK }} == P1Y ]]; then
                         find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
                     else
                         find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
                     fi
-                else
-                    echo "Skipping '$dir' as it does not exist"
-                fi
-            done
-        """
-
-{% if DO_SECONDARY_PP %}
-    [[clean-shards-{{ PP_CHUNK_B }}]]
-        inherit = CLEAN
-        script = """
-            dirs="$CYLC_WORKFLOW_SHARE_DIR/shards/*/native/*/*/{{ PP_CHUNK_B }} $CYLC_WORKFLOW_SHARE_DIR/shards/*/regrid-xy/*/*/*/{{ PP_CHUNK_B }}"
-            for dir in $dirs; do
-                if [[ -d $dir ]]; then
-                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
-                else
-                    echo "Skipping '$dir' as it does not exist"
-                fi
-            done
-        """
-{% endif %}
-
-    [[clean-pp-timeavgs-{{ PP_CHUNK_A }}]]
-        inherit = CLEAN
-        script = """
-            dirs=$CYLC_WORKFLOW_SHARE_DIR/pp/av/*/*/{{ PP_CHUNK_A }}
-            for dir in $dirs; do
-                if [[ {{ PP_CHUNK_A }} == P1Y ]]; then
-                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*.nc" -print -delete
-                else
-                    find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
-                fi
-            done
-        """
-
-{% if DO_SECONDARY_PP %}
-    [[clean-pp-timeavgs-{{ PP_CHUNK_B }}]]
-        inherit = CLEAN
-        script = """
-            dirs=$CYLC_WORKFLOW_SHARE_DIR/pp/av/*/*/{{ PP_CHUNK_B }}
-            for dir in $dirs; do
-                find $dir -type f -name "*.$(cylc cycle-point --template CCYY)*-*.nc" -print -delete
-            done
-        """
-{% endif %}
-
-
+                done
+            """
+    {% endfor %}
 
 # Site-specific settings
 {% include 'site/' ~ SITE ~ '.cylc' %}

--- a/flow.cylc
+++ b/flow.cylc
@@ -768,7 +768,9 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
 {% endif %}
 
     [[DATA-CATALOG]]
-        script = rose task-run --verbose --app-key data-catalog
+        script = data-catalog
+	[[[environment]]]
+	    PP_DIR = {{ PP_DIR }}
     [[data-catalog-final]]
         inherit = DATA-CATALOG
 

--- a/site/gaea.cylc
+++ b/site/gaea.cylc
@@ -76,7 +76,7 @@
     [[REMAP-PP-COMPONENTS]]
         pre-script = module load cdo gcp && mkdir -p $outputDir
 
-    [[data-catalog]]
+    [[DATA-CATALOG]]
         pre-script = module load fre/{{ FRE_VERSION }}
 
     [[MAKE-TIMESERIES]]

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -84,7 +84,7 @@
             mkdir -p $outputDir
         """
 
-    [[data-catalog]]
+    [[DATA-CATALOG]]
         pre-script = module load fre/{{ FRE_VERSION }} 
         
     [[MAKE-TIMESERIES]]

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -124,7 +124,7 @@
             mkdir -p $outputDir
         """
 
-    [[data-catalog]]
+    [[DATA-CATALOG]]
         env-script = """
             {{ EPMT_PREAMBLE }}
             epmt annotate EPMT_JOB_TAGS="exp_name:{{ EXPERIMENT }};exp_fre_mod:{{ FRE_VERSION }};exp_platform:{{ PLATFORM }};exp_target:{{ TARGET }};exp_component:data-catalog:exp_component_source:PLACE_HOLDER;exp_time:$CYLC_TASK_CYCLE_POINT;exp_seg_months:{{ HISTORY_SEGMENT }};pp_chunk_a_months:{{ MOS_PER_CHUNK_A }};pp_chunk_b_months:{{ MOS_PER_CHUNK_B }};script_name:$CYLC_TASK_NAME;exp_run_uuid:$CYLC_WORKFLOW_UUID"


### PR DESCRIPTION
Changes to `get_analysis_info`:
* Revise `graph` to run on the correct cycle points.
* Revise `choose_pp_chunk` to accept a list of chunk sizes.
* Eliminate use of `TimePointDumper`; access the `year` attribute of TimePoint objects instead.
* Run `data-catalog` as an analysis task pre-script.

Changes to cylc configuration:
* Eliminate all references to `PP_CHUNK_A` and `PP_CHUNK_B` in flow.cylc; loop over `PP_CHUNKS` instead.
* Create `data-catalog` script which runs `fre catalog builder` only when necessary.
* Eliminate `data-catalog` task from flow.cylc
* Run `data-catalog` at the end of the workflow via a shutdown handler.