### PR TITLE
65.update remap tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *~
 tests/test_files_papiex_tooler/*tags
+app/remap-pp-components/test-outDir

--- a/app/remap-pp-components/remap_pp_components.py
+++ b/app/remap-pp-components/remap_pp_components.py
@@ -1,0 +1,1 @@
+bin/remap-pp-components

--- a/app/remap-pp-components/t/test_remap-pp-components.py
+++ b/app/remap-pp-components/t/test_remap-pp-components.py
@@ -54,7 +54,18 @@ else:
     Path(REMAP_OUT).mkdir(parents=True,exist_ok=True)
 
 
-##REMAP NOW USES YAML CONFIG, NOT ROSE APPS
+def test_cdl_file_exists(capfd):
+    """
+    Test for the existence of cdl test file
+    """
+    assert Path(f"{DATA_DIR}/{DATA_FILE_CDL}").exists()
+
+def test_yaml_ex_exists(capfd):
+    """
+    Test for the existence of example yaml configuration
+    """
+    assert Path(YAML_EX).exists()
+
 def test_create_ncfile_with_ncgen_cdl(capfd):
     """
     Check for the creation of required directories

--- a/app/remap-pp-components/t/test_remap-pp-components.py
+++ b/app/remap-pp-components/t/test_remap-pp-components.py
@@ -3,15 +3,23 @@ import subprocess
 import shutil
 from pathlib import Path
 import pytest
+from remap_pp_components import remap
 
-cwd = os.getcwd()
+CWD = os.getcwd()
 
 # Path to test data
-DATA_DIR  = Path(f"{cwd}/test-data")
+DATA_DIR  = Path(f"{CWD}/test-data")
 # CDL file to generate nc file from ncgen
 DATA_FILE_CDL = Path("atmos_scalar.198001-198412.co2mass.cdl")
 # Create NC file name to test remap functionality
 DATA_FILE_NC = Path("atmos_scalar.198001-198412.co2mass.nc")
+# YAML configuration example file
+YAML_EX = f"{DATA_DIR}/yaml_ex.yaml"
+
+# Define/create necessary locatiions
+TEST_OUTDIR = f"{CWD}/test-outDir"
+REMAP_IN = f"{TEST_OUTDIR}/ncgen-output"
+REMAP_OUT = f"{TEST_OUTDIR}/remap-output"
 
 # Define variables
 COMPOUT = "atmos_scalar"
@@ -21,30 +29,39 @@ CHUNK = "P5Y"
 PRODUCT = "ts"
 COPY_TOOL = "cp"
 
-#Define/create necessary locatiions
-test_outDir = Path(f"{cwd}/test-outDir")
-remap_in = test_outDir / "ncgen-output"
-remap_out = test_outDir / "remap-output"
+# environment variables
+os.environ['inputDir'] = REMAP_IN
+os.environ['outputDir'] = REMAP_OUT
+os.environ['currentChunk'] = "P5Y"
+os.environ['components'] = COMPOUT
+os.environ['begin'] = "19800101T0000Z"
+os.environ['product'] = PRODUCT
+os.environ['dirTSWorkaround'] = "1"
+os.environ['ens_mem'] = ""
+os.environ['COPY_TOOL'] = COPY_TOOL
+os.environ['yaml_config'] = YAML_EX
 
 # Set up input directory (location previously made in flow.cylc workflow)
-ncgen_out = Path(remap_in) / GRID / COMPOUT / FREQ / CHUNK
+ncgen_out = Path(REMAP_IN) / GRID / COMPOUT / FREQ / CHUNK
 
 #If output directory exists, remove and create again
-if Path(test_outDir).exists():
-    shutil.rmtree(test_outDir)
+if Path(TEST_OUTDIR).exists():
+    shutil.rmtree(TEST_OUTDIR)
     Path(ncgen_out).mkdir(parents=True,exist_ok=True)
-    Path(remap_out).mkdir(parents=True,exist_ok=True)
+    Path(REMAP_OUT).mkdir(parents=True,exist_ok=True)
 else:
     Path(ncgen_out).mkdir(parents=True,exist_ok=True)
-    Path(remap_out).mkdir(parents=True,exist_ok=True)
+    Path(REMAP_OUT).mkdir(parents=True,exist_ok=True)
 
+
+##REMAP NOW USES YAML CONFIG, NOT ROSE APPS
 def test_create_ncfile_with_ncgen_cdl(capfd):
     """
-       Check for the creation of required directories
-       and a *.nc file from *.cdl text file using
-       command ncgen. This file will be used as an input
-       file for the rewrite remap tests.
-       Test checks for success of ncgen command.
+    Check for the creation of required directories
+    and a *.nc file from *.cdl text file using
+    command ncgen. This file will be used as an input
+    file for the rewrite remap tests.
+    Test checks for success of ncgen command.
     """
     print(f"NCGEN OUTPUT DIRECTORY: {ncgen_out}")
 
@@ -66,54 +83,47 @@ def test_create_ncfile_with_ncgen_cdl(capfd):
     out, err = capfd.readouterr()
 
 def test_remap_pp_components(capfd):
-    """Checks for success of remapping a file with rose app using
-       the remap-pp-components script as the valid definitions
-       are being called by the environment.
     """
-    # script: directory with /bin folder with remap script
-    script = Path(cwd)
-
-    # Create a test rose-app configuration
-    ex = [ "rose", "app-run",
-           '-D',  '[env]inputDir='f'{remap_in}',
-           '-D',  '[env]outputDir='f'{remap_out}',
-           '-D',  '[env]currentChunk=P5Y',
-           '-D',  '[env]components='f'"{COMPOUT}"',
-           '-D',  '[env]begin=19800101T0000Z',
-           '-D',  '[env]product='f'{PRODUCT}',
-           '-D',  '[env]dirTSWorkaround=1',
-           '-D',  '[env]ens_mem=',
-           '-D',  '[env]COPY_TOOL='f'{COPY_TOOL}',
-           '-D',  '[atmos_scalar]grid='f'{GRID}',
-           '-D',  '[atmos_scalar]sources=atmos_scalar',
-           '-C',  script
-         ]
-
-    print (ex)
-
-    # Run the rewritten remap-pp-components script using the rose-app configuration
-    sp = subprocess.run( ex, check = False )
+    Checks for success of remapping a file with rose app using
+    the remap-pp-components script as the valid definitions
+    are being called by the environment.
+    """
+    # run script
+    try:
+        remap()
+    except:
+        assert False
 
     # Check for
-    # 1. success of remap script
-    # 2. creation of output directory structre,
-    # 3. link to nc file in output location
-    assert all([sp.returncode == 0,
-                Path(remap_out/COMPOUT/PRODUCT/FREQ/CHUNK).exists(),
-                Path(remap_out/COMPOUT/PRODUCT/FREQ/CHUNK/DATA_FILE_NC).exists()])
+    # 1. creation of output directory structre,
+    # 2. link to nc file in output location
+    assert all([Path(f"{REMAP_OUT}/{COMPOUT}/{PRODUCT}/monthly/5yr").exists(),
+                Path(f"{REMAP_OUT}/{COMPOUT}/{PRODUCT}/monthly/5yr/{DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
 
-def test_remap_pp_components_with_ensmem(capfd):
-    """Checks for success of remapping a file with rose app config using
-       the remap-pp-components script when ens_mem is defined.
-    """
-    # script: directory with /bin folder with remap script
-    script = Path(cwd)
+ ####are freq and chunk supposed to be like that?####
 
+def test_remap_pp_components_with_ensmem(capfd):
+    """
+    Checks for success of remapping a file with rose app config using
+    the remap-pp-components script when ens_mem is defined.
+    """
     # Redefine ens input and output directories
-    remap_ens_in = test_outDir / "ncgen-ens-output"
+    remap_ens_in = f"{TEST_OUTDIR}/ncgen-ens-output"
     ncgen_ens_out = Path(remap_ens_in) / GRID / "ens_01" / COMPOUT / FREQ / CHUNK
-    remap_ens_out = test_outDir / "remap-ens-output"
+    remap_ens_out = f"{TEST_OUTDIR}/remap-ens-output"
+
+    # Specify environment variables
+    os.environ['inputDir'] = remap_ens_in
+    os.environ['outputDir'] = remap_ens_out
+    os.environ['currentChunk'] = "P5Y"
+    os.environ['components'] = COMPOUT
+    os.environ['begin'] = "19800101T0000Z"
+    os.environ['product'] = PRODUCT
+    os.environ['dirTSWorkaround'] = "1"
+    os.environ['ens_mem'] = "ens_01"
+    os.environ['COPY_TOOL'] = COPY_TOOL
+    os.environ['yaml_config'] = YAML_EX
 
     # Create ensemble locations
     Path(ncgen_ens_out).mkdir(parents=True,exist_ok=True)
@@ -122,129 +132,89 @@ def test_remap_pp_components_with_ensmem(capfd):
     # Make sure input nc file is also in ens input location
     shutil.copyfile(Path(ncgen_out) / DATA_FILE_NC, Path(ncgen_ens_out) / DATA_FILE_NC)
 
-    # Create a test rose-app configuration
-    ex = [ "rose", "app-run",
-           '-D',  '[env]inputDir='f'{remap_ens_in}',
-           '-D',  '[env]outputDir='f'{remap_ens_out}',
-           '-D',  '[env]currentChunk=P5Y',
-           '-D',  '[env]components='f'"{COMPOUT}"',
-           '-D',  '[env]begin=19800101T0000Z',
-           '-D',  '[env]product='f'{PRODUCT}',
-           '-D',  '[env]dirTSWorkaround=1',
-           '-D',  '[env]ens_mem=ens_01',
-           '-D',  '[env]COPY_TOOL='f'{COPY_TOOL}',
-           '-D',  '[atmos_scalar]grid='f'{GRID}',
-           '-D',  '[atmos_scalar]sources=atmos_scalar',
-           '-C',  script
-         ]
-
-    print (ex)
-
-    # Run the rewritten remap-pp-components script using the rose-app configuration
-    sp = subprocess.run( ex, check = False )
+    # run script
+    try:
+        remap()
+    except:
+        assert False
 
     # Check for
-    # 1. success of remap script
-    # 2. creation of output directory structre,
-    # 3. link to nc file in output location
-    assert all([sp.returncode == 0,
-                Path(remap_ens_out/COMPOUT/PRODUCT/"ens_01"/FREQ/CHUNK).exists(),
-                Path(remap_ens_out/COMPOUT/PRODUCT/"ens_01"/FREQ/CHUNK/DATA_FILE_NC).exists()])
+    # 1. creation of output directory structre,
+    # 2. link to nc file in output location
+    assert all([Path(f"{remap_ens_out}/{COMPOUT}/{PRODUCT}/{os.getenv('ens_mem')}/monthly/5yr").exists(),
+                Path(f"{remap_ens_out}/{COMPOUT}/{PRODUCT}/{os.getenv('ens_mem')}/monthly/5yr/{DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
 
+@pytest.mark.xfail #uncomment to ensure it's the right failure
 def test_remap_pp_components_product_failure(capfd):
-    """Checks for failure of remapping a file with rose app using
-       the remap-pp-components script when the product is ill-defined.
-       (not ts or av)
     """
-    # script: directory with /bin folder with remap script
-    script = Path(cwd)
+    Checks for failure of remapping a file with rose app using
+    the remap-pp-components script when the product is ill-defined.
+    (not ts or av)
+    """
+    # Specify environment variables
+    os.environ['inputDir'] = REMAP_IN
+    os.environ['outputDir'] = REMAP_OUT
+    os.environ['currentChunk'] = "P5Y"
+    os.environ['components'] = COMPOUT
+    os.environ['begin'] = "19800101T0000Z"
+    os.environ['product'] = "not-ts-or-av" # change product value
+    os.environ['dirTSWorkaround'] = "1"
+    os.environ['ens_mem'] = ""
+    os.environ['COPY_TOOL'] = COPY_TOOL
+    os.environ['yaml_config'] = YAML_EX
 
-    # Create a test rose-app configuration
-    ex = [ "rose", "app-run",
-           '-D',  '[env]inputDir='f'{remap_in}',
-           '-D',  '[env]outputDir='f'{remap_out}',
-           '-D',  '[env]currentChunk=P5Y',
-           '-D',  '[env]components='f'"{COMPOUT}"',
-           '-D',  '[env]begin=19800101T0000Z',
-           '-D',  '[env]product=not-ts-or-av',
-           '-D',  '[env]dirTSWorkaround=1',
-           '-D',  '[env]ens_mem=',
-           '-D',  '[env]COPY_TOOL='f'{COPY_TOOL}',
-           '-D',  '[atmos_scalar]grid='f'{GRID}',
-           '-D',  '[atmos_scalar]sources=atmos_scalar',
-           '-C',  script
-         ]
+    # run script
+    remap()
 
-    print (ex)
-
-    # Run the rewritten remap-pp-components script using the rose-app configuration
-    sp = subprocess.run( ex, check = False )
-
-    # Check for
-    # 1. failure of remap script
-    assert sp.returncode != 0
-    out, err = capfd.readouterr()
-
+@pytest.mark.xfail
 def test_remap_pp_components_begin_date_failure(capfd):
-    """Checks for failure of remapping a file with rose app using
-       the remap-pp-components script when the begin variable is
-       ill-defined.
     """
-    # script: directory with /bin folder with remap script
-    script = Path(cwd)
+    Checks for failure of remapping a file with rose app using
+    the remap-pp-components script when the begin variable is
+    ill-defined.
+    """
+    # Specify environment variables
+    os.environ['inputDir'] = REMAP_IN
+    os.environ['outputDir'] = REMAP_OUT
+    os.environ['currentChunk'] = "P5Y"
+    os.environ['components'] = COMPOUT
+    os.environ['begin'] = "123456789T0000Z" # change begin value
+    os.environ['product'] = PRODUCT
+    os.environ['dirTSWorkaround'] = "1"
+    os.environ['ens_mem'] = ""
+    os.environ['COPY_TOOL'] = COPY_TOOL
+    os.environ['yaml_config'] = YAML_EX
 
-    # Create a test rose-app configuration
-    ex = [ "rose", "app-run",
-           '-D',  '[env]inputDir='f'{remap_in}',
-           '-D',  '[env]outputDir='f'{remap_out}',
-           '-D',  '[env]currentChunk=P5Y',
-           '-D',  '[env]components='f'"{COMPOUT}"',
-           '-D',  '[env]begin=123456789T0000Z',
-           '-D',  '[env]product='f'{PRODUCT}',
-           '-D',  '[env]dirTSWorkaround=1',
-           '-D',  '[env]ens_mem=',
-           '-D',  '[env]COPY_TOOL='f'{COPY_TOOL}',
-           '-D',  '[atmos_scalar]grid='f'{GRID}',
-           '-D',  '[atmos_scalar]sources=atmos_scalar',
-           '-C',  script
-         ]
+    # run script
+    remap()
 
-    print (ex)
-
-    # Run the rewritten remap-pp-components script using the rose-app configuration
-    sp = subprocess.run( ex, check = False )
-
-    # Check for
-    # 1. failure of remap script
-    assert sp.returncode != 0
-    out, err = capfd.readouterr()
-
-# Comparison
+# Comparison tests
 def test_nccmp_ncgen_remap(capfd):
-    """This test compares the results of ncgen and rewrite_remap,
-        making sure that the remapped files are identical.
+    """
+    This test compares the results of ncgen and rewrite_remap,
+    making sure that the remapped files are identical.
     """
     nccmp = [ "nccmp", "-d",
-              Path(remap_in) / GRID / COMPOUT / FREQ / CHUNK / DATA_FILE_NC,
-              Path(remap_out) / COMPOUT / PRODUCT / FREQ / CHUNK / DATA_FILE_NC ]
+              Path(f"{REMAP_IN}/{GRID}/{COMPOUT}/{FREQ}/{CHUNK}/{DATA_FILE_NC}"),
+              Path(f"{REMAP_OUT}/{COMPOUT}/{PRODUCT}/monthly/5yr/{DATA_FILE_NC}") ]
 
     sp = subprocess.run( nccmp, check = False)
     assert sp.returncode == 0
     out, err = capfd.readouterr()
 
-# Comparison
 def test_nccmp_ncgen_remap_ens_mem(capfd):
-    """This test compares the results of ncgen and rewrite_remap,
-        making sure that the remapped files are identical.
+    """
+    This test compares the results of ncgen and rewrite_remap,
+    making sure that the remapped files are identical.
     """
     # Redefine ens input and output directories
-    remap_ens_in = test_outDir / "ncgen-ens-output"
-    remap_ens_out = test_outDir / "remap-ens-output"
+    remap_ens_in = f"{TEST_OUTDIR}/ncgen-ens-output"
+    remap_ens_out = f"{TEST_OUTDIR}/remap-ens-output"
 
     nccmp = [ "nccmp", "-d",
-              Path(remap_ens_in) / GRID / "ens_01" / COMPOUT / FREQ / CHUNK / DATA_FILE_NC,
-              Path(remap_ens_out) / COMPOUT / PRODUCT / "ens_01" / FREQ / CHUNK / DATA_FILE_NC ]
+              Path(f"{remap_ens_in}/{GRID}/ens_01/{COMPOUT}/{FREQ}/{CHUNK}/{DATA_FILE_NC}"),
+              Path(f"{remap_ens_out}/{COMPOUT}/{PRODUCT}/ens_01/monthly/5yr/{DATA_FILE_NC}") ]
 
     sp = subprocess.run( nccmp, check = False)
     assert sp.returncode == 0

--- a/app/remap-pp-components/test-data/yaml_ex.yaml
+++ b/app/remap-pp-components/test-data/yaml_ex.yaml
@@ -1,0 +1,18 @@
+postprocess:
+  components:
+    - type: "atmos"
+      sources:
+        - history_file: "atmos_month"
+      sourceGrid: "cubedsphere"
+      xyInterp: "180, 288"
+      interpMethod: "conserve_order2"
+      inputRealm: "atmos"
+      static: 
+      - source: "atmos_static_cmip"
+        variables: ["grid_xt", "grid_yt", "time", "orog"]
+      postprocess_on: False
+    - type: "atmos_scalar"
+      sources:
+        - history_file: "atmos_scalar"
+      inputRealm: "atmos"
+      postprocess_on: True


### PR DESCRIPTION
Changes to `remap-pp-components` script include no longer using the rose-app configuration. It now just reads and parses the yaml configuration.

This PR updates the remap-pp-components test to account for that script update and no longer uses rose-app configurations.

This PR will stay in draft mode until https://github.com/NOAA-GFDL/fre-workflows/pull/62 is merged