### PR TITLE
Minor

### DIFF
--- a/app/regrid-xy/regrid_xy.py
+++ b/app/regrid-xy/regrid_xy.py
@@ -440,7 +440,8 @@ def regrid_xy( ):
             fregrid_command.append(f'{more_options}')
 
         print(f"\n\nabout to run the following command: \n{' '.join(fregrid_command)}\n")
-        fregrid_proc = subprocess.run( fregrid_command, check = False )#i hate it
+        # will raise an CalledProcessError exception on failure
+        fregrid_proc = subprocess.run( fregrid_command, check = True )
         fregrid_rc =fregrid_proc.returncode
         print(f'fregrid_result.returncode()={fregrid_rc}')
 

--- a/app/regrid-xy/regrid_xy.py
+++ b/app/regrid-xy/regrid_xy.py
@@ -16,8 +16,6 @@ import ast
 import metomi.rose.config as rose_cfg
 from netCDF4 import Dataset
 
-FREGRID_SHARED_FILES='/home/fms/shared_fregrid_remap_files'
-
 # formerly in shared.sh
 def truncate_date(date, freq):
     format=freq_to_date_format(freq)
@@ -376,22 +374,14 @@ def regrid_xy( ):
             remap_cache_file = \
                 f'{remap_dir}/{input_grid}/{input_realm}/' + \
                 f'{source_nx}-by-{source_ny}/{interp_method}/{remap_file}'
-            central_remap_cache_file = \
-                f'{FREGRID_SHARED_FILES}/{input_grid}/' + \
-                f'{source_nx}_by_{source_ny}/{remap_file}'
 
             print(f'remap_file               = {remap_file              }' + \
-                  f'remap_cache_file         = {remap_cache_file        }' + \
-                  f'central_remap_cache_file = {central_remap_cache_file}' )
+                  f'remap_cache_file         = {remap_cache_file        }')
 
             if Path( remap_cache_file ).exists():
                 print(f'NOTE: using cached remap file {remap_cache_file}')
                 shutil.copy(remap_cache_file,
                             remap_cache_file.split('/').pop())
-            elif Path( central_remap_cache_file ).exists():
-                print(f'NOTE: using centrally cached remap file {remap_cache_file}')
-                shutil.copy(central_remap_cache_file,
-                            central_remap_cache_file.split('/').pop())
 
 
 

--- a/app/regrid-xy/regrid_xy.py
+++ b/app/regrid-xy/regrid_xy.py
@@ -16,6 +16,16 @@ import ast
 import metomi.rose.config as rose_cfg
 from netCDF4 import Dataset
 
+# these variables will cause fregrid errors
+# they should have variable attribute interp_method=NONE
+# from the model but they do not, yet
+non_regriddable_variables = [
+    'geolon_c', 'geolat_c', 'geolon_u', 'geolat_u', 'geolon_v', 'geolat_v',
+    'FA_X', 'FA_Y', 'FI_X', 'FI_Y', 'IX_TRANS', 'IY_TRANS', 'UI', 'VI', 'UO', 'VO',
+    'wet_c', 'wet_v', 'wet_u', 'dxCu', 'dyCu', 'dxCv', 'dyCv', 'Coriolis',
+    'areacello_cu', 'areacello_cv', 'areacello_bu'
+]
+
 # formerly in shared.sh
 def truncate_date(date, freq):
     format=freq_to_date_format(freq)
@@ -147,6 +157,8 @@ def make_regrid_var_list(target_file, interp_method = None):
     for var_name in all_fin_vars:
         if var_name in ['average_T1','average_T2',
                         'average_DT','time_bnds' ]:
+            continue
+        if var_name in non_regriddable_variables:
             continue
         if len(all_fin_vars[var_name].shape) < 2 :
             continue

--- a/flow.cylc
+++ b/flow.cylc
@@ -402,6 +402,13 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
                  echo "Error: Cant stage history files in ${file} to PTMP"
                  exit 1
             fi
+
+            # Finally, link these files to $CYLC_WORKFLOW_SHARE_DIR
+            mkdir -p $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
+            cd $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
+            ln -f $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* . \
+                || ln -sf $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* .
+
             #Data Integrity Checking:q
             fre pp histval --warn --history $ptmpDir$historyDir/$(basename -s .tar $file) --date_string $(cylc cycle-point --template CCYYMMDD)
             # Setup PYTHONPATH and io lists for the data lineage tool
@@ -411,12 +418,6 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
                 export output_file_list=
                 echo "Set PYTHONPATH and created i/o lists"
             fi
-
-            # Finally, link these files to $CYLC_WORKFLOW_SHARE_DIR
-            mkdir -p $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
-            cd $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
-            ln -f $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* . \
-                || ln -sf $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* .
 
             if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
                 outputDir=$CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native


### PR DESCRIPTION
Small updates during esm45 testing
* add hard-coded "do not regrid" list for certain variables
* do not use regrid files in fms home directory
* check the return code of fregrid
* link history files before `fre pp histval` instead of before to let users "set outputs" in the case of ocean regional files that have incorrect diag manifest timesteps