### PR TITLE
Run history validation after the linking

### DIFF
--- a/flow.cylc
+++ b/flow.cylc
@@ -402,15 +402,15 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
                  echo "Error: Cant stage history files in ${file} to PTMP"
                  exit 1
             fi
-            
-            #Data Integrity Checking
-            fre -v pp histval --warn --history $ptmpDir$historyDir/$(basename -s .tar $file) --date_string $(cylc cycle-point --template CCYYMMDD)
 
             # Finally, link these files to $CYLC_WORKFLOW_SHARE_DIR
             mkdir -p $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
             cd $CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
             ln -f $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* . \
                 || ln -sf $ptmpDir/$historyDir/$(cylc cycle-point --template CCYYMMDD).nc/* .
+
+            #Data Integrity Checking
+            fre -v pp histval --warn --history $ptmpDir$historyDir/$(basename -s .tar $file) --date_string $(cylc cycle-point --template CCYYMMDD)
 
             # Setup PYTHONPATH and io lists for the data lineage tool
             if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then


### PR DESCRIPTION
So that an incorrect error can be bypassed by cylc intervention to set the 'stage-history' to succeeded, e.g.:

cylc set 'NAME/*/stage-history'