### PR TITLE
Remove unneeded "mkdir -p $outputDir" for regridding tasks

### DIFF
--- a/site/gaea.cylc
+++ b/site/gaea.cylc
@@ -93,7 +93,6 @@
         pre-script = """
             module load fre/{{ FRE_VERSION }}
             module load fre-nctools/2023.01.02 nco
-            mkdir -p $outputDir
         """
         [[[environment]]]
             TMPDIR = $CYLC_TASK_WORK_DIR

--- a/site/generic.cylc
+++ b/site/generic.cylc
@@ -38,11 +38,6 @@
 
 #{% endif %}
 
-{% if DO_REGRID %}
-    [[REGRID-XY]]
-        pre-script = mkdir -p $outputDir
-{% endif %}
-
 {% if DO_MDTF %}
     [[mdtf]]
         pre-script = mkdir -p $MDTF_TMPDIR

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -103,7 +103,6 @@
             module load fre/{{ FRE_VERSION }}
             module load fre-nctools/2024.05
             which fregrid
-            mkdir -p $outputDir
         """
 {% endif %}
 

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -132,9 +132,6 @@
         """
         pre-script = module load fre/{{ FRE_VERSION }} 
         
-        [[[directives]]]
-            --partition=analysis
-
     [[MAKE-TIMESERIES]]
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
@@ -146,17 +143,11 @@
 
 {% if DO_REGRID %}
     [[REGRID-XY]]
+        execution time limit = P1D
         pre-script = """
-            # the conda activate below brings in an old fre-nctools
-            # that is conda installable. we need an updated
-            # fre-nctools to regrid new ocean output
-            module load miniforge
-            set +u
-            conda activate /nbhome/fms/conda/envs/fre-2025.01
-            set -u
+            module load fre/{{ FRE_VERSION }}
             module load fre-nctools/2024.05
             which fregrid
-            mkdir -p $outputDir
         """
 {% endif %}
 


### PR DESCRIPTION
'fre pp regrid' does the mkdir itself.

https://github.com/NOAA-GFDL/fre-cli/blob/main/fre/app/regrid_xy/regrid_xy.py#L198