### PR TITLE
Fix postprocessing of static files in rename-split-to-pp

### DIFF
--- a/app/rename-split-to-pp/bin/rename-split-to-pp
+++ b/app/rename-split-to-pp/bin/rename-split-to-pp
@@ -15,7 +15,7 @@ function process_files {
         my_path=
     fi
     
-    files_processed_count=1
+    files_processed_count=0
     for file in $files; do
         # tiled or non-tiled
         if (( $(echo $file | grep -o '\.' | wc -l) == 4 )); then


### PR DESCRIPTION
This is meant to fix issue #82  - detection of static files fails in rename-split-to-pp, leading to static files never getting processed, leading to a failure in remap--pp-components. 

Fixes: 
  - fix the check for static files (timeseries of length 1)
  - throw an error from within the tool if no files are processed (makes it easier to track down bugs)