### PR TITLE
84.get src varlist

### DIFF
--- a/Jinja2Filters/get_variables.py
+++ b/Jinja2Filters/get_variables.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import os
 from pathlib import Path
 import yaml
@@ -21,7 +20,6 @@ def get_variables(yamlfile, pp_components):
     fre_logger.debug(f"PP components: {pp_components}")
 
     pp_comp = pp_components.split()
-#    print(pp_comp)
     with open(yamlfile) as file_:
         yml = yaml.safe_load(file_)
 
@@ -56,4 +54,4 @@ def get_variables(yamlfile, pp_components):
     return src_vars
 
 ## TEST ##
-print(get_variables("/home/Dana.Singh/fre/get-vars-jinjafilter/Jinja2Filters/yaml_ex.yaml", "atmos_scalar atmos_scalar_test_vars atmos_scalar_test_vars_fail atmos_scalar_static_test_vars_fail"))
+#print(get_variables("/home/Dana.Singh/fre/get-vars-jinjafilter/Jinja2Filters/yaml_ex.yaml", "atmos_scalar atmos_scalar_test_vars atmos_scalar_test_vars_fail atmos_scalar_static_test_vars_fail"))

--- a/Jinja2Filters/get_variables.py
+++ b/Jinja2Filters/get_variables.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import os
+from pathlib import Path
+import yaml
+
+# set up logging
+import logging
+logging.basicConfig(level=logging.INFO)
+fre_logger = logging.getLogger(__name__)
+
+def get_variables(yamlfile, pp_components):
+    """
+    Retrieve any variables specified with active 
+    pp components from the yaml
+
+    Arguments:
+        yamlfile (str): Filepath to the yaml
+        pp_components (str): Space separated list of active pp components
+    """
+    fre_logger.debug(f"Yaml file: {yamlfile}")
+    fre_logger.debug(f"PP components: {pp_components}")
+
+    pp_comp = pp_components.split()
+#    print(pp_comp)
+    with open(yamlfile) as file_:
+        yml = yaml.safe_load(file_)
+
+    src_vars={}
+    for component_info in yml["postprocess"]["components"]:
+        # if component in yaml not an active pp component, skip
+        if component_info.get("type") not in pp_comp:
+            fre_logger.info(f'{component_info.get("type")} not in list of pp components: {pp_comp}')
+            continue
+
+        # non-static
+        src_info = component_info.get("sources")
+        for src_elem in src_info:
+            # if variables are defined, append to dictionary
+            if src_elem.get("variables"):
+                src_vars[src_elem.get("history_file")] = src_elem.get("variables")
+            else:
+                src_vars[src_elem.get("history_file")] = "all"
+
+        # static
+        if component_info.get("static"):
+            static_info = component_info.get("static")
+            for static_elem in static_info:
+                # if variables are defined, append to dictionary
+                if static_elem.get("variables"):
+                    src_vars[static_elem.get("source")] = static_elem.get("variables")
+                else:
+                    src_vars[static_elem.get("source")] = "all"
+
+        ##offline statics won't use variables filtering ... yet?
+
+    return src_vars
+
+## TEST ##
+print(get_variables("/home/Dana.Singh/fre/get-vars-jinjafilter/Jinja2Filters/yaml_ex.yaml", "atmos_scalar atmos_scalar_test_vars atmos_scalar_test_vars_fail atmos_scalar_static_test_vars_fail"))

--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -190,7 +190,10 @@ def search_files(product,var,source,freq,current_chunk,begin):
             files.extend(f)
         else:
             for v in var:
+                logger.info("var: %s", v)
                 f = glob.glob(f"{source}.{v}*.nc")
+                if not f: #if glob returns empty list
+                    raise ValueError("Variable {v} could not be found or does not exist.")
                 files.extend(f)
     else:
         if product == "ts":
@@ -208,6 +211,8 @@ def search_files(product,var,source,freq,current_chunk,begin):
             for v in var:
                 logger.info("var: %s", v)
                 f = glob.glob(f"{source}.{date}-*.{v}*.nc")
+                if not f: #if glob returns empty list
+                    raise ValueError("Variable {v} could not be found or does not exist.")
                 files.extend(f)
 
         if product == "av" and current_chunk == "P1Y":

--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -242,30 +242,6 @@ def get_variables(comp_info, product, req_source, src_vars):
         if req_source == src_name:
             v = src_vars[req_source]
 
-#    if product == "static":
-#        if comp_info.get("static") is None:
-#            raise ValueError(f"Product is set to static but no static sources/variables defined for {comp_info.get('type')}")
-#
-#        for static_info in comp_info.get("static"):
-#            if static_info.get("source") == req_source:
-#                if static_info.get("variables") is None:
-#                    v = "all"
-#                else:
-#                    v = static_info.get("variables")
-#
-##            if static_info.get("offline_source") is not None:
-##                if static_info.get("variables") is None:
-##                    v = "all"
-##                else:
-##                    v = static_info.get("variables")
-#    else:
-#        for src_info in comp_info.get("sources"): #history_file,variables
-#            if src_info.get("history_file") == req_source:
-#                if src_info.get("variables") is None:
-#                    v = "all"
-#                else:
-#                    v = src_info.get("variables")
-#
     return v
 
 def get_sources(comp_info, product):

--- a/app/remap-pp-components/bin/remap-pp-components
+++ b/app/remap-pp-components/bin/remap-pp-components
@@ -11,6 +11,7 @@ import glob
 from pathlib import Path
 import logging
 import yaml
+import ast
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -215,37 +216,51 @@ def search_files(product,var,source,freq,current_chunk,begin):
 
     return files
 
-def get_variables(comp_info, product, req_source):
+def get_variables(comp_info, product, req_source, src_vars):
     """
     Retrieve variables listed for a component; save in dictionary for use later
     Params:
         comp_info: dictionary of information about requested component
         product: static, ts, or av
+        req_source: source being assessed
+        src_vars: dictionary of defined variables with associated sources
     """
     if product == "static":
         if comp_info.get("static") is None:
             raise ValueError(f"Product is set to static but no static sources/variables defined for {comp_info.get('type')}")
 
-        for static_info in comp_info.get("static"):
-            if static_info.get("source") == req_source:
-                if static_info.get("variables") is None:
-                    v = "all"
-                else:
-                    v = static_info.get("variables")
+    ## Dictionary of variables associated with pp component source name are retrieved through Jinjafilter get_variables.py
+    # 1. Loop through each element in dictionary passed
+    # 2. match pp component source name with the requested source being assessed
+    # 3. Save variables associated with that pp component 
+    for src_name in src_vars.keys():
+        if req_source == src_name:
+            v = src_vars[req_source]
 
-#            if static_info.get("offline_source") is not None:
+#    if product == "static":
+#        if comp_info.get("static") is None:
+#            raise ValueError(f"Product is set to static but no static sources/variables defined for {comp_info.get('type')}")
+#
+#        for static_info in comp_info.get("static"):
+#            if static_info.get("source") == req_source:
 #                if static_info.get("variables") is None:
 #                    v = "all"
 #                else:
 #                    v = static_info.get("variables")
-    else:
-        for src_info in comp_info.get("sources"): #history_file,variables
-            if src_info.get("history_file") == req_source:
-                if src_info.get("variables") is None:
-                    v = "all"
-                else:
-                    v = src_info.get("variables")
-
+#
+##            if static_info.get("offline_source") is not None:
+##                if static_info.get("variables") is None:
+##                    v = "all"
+##                else:
+##                    v = static_info.get("variables")
+#    else:
+#        for src_info in comp_info.get("sources"): #history_file,variables
+#            if src_info.get("history_file") == req_source:
+#                if src_info.get("variables") is None:
+#                    v = "all"
+#                else:
+#                    v = src_info.get("variables")
+#
     return v
 
 def get_sources(comp_info, product):
@@ -313,6 +328,7 @@ def remap():
     current_chunk     = os.getenv('currentChunk')
     components        = os.getenv('components')
     yaml_config       = os.getenv('yaml_config')
+    src_vars_dict     = ast.literal_eval(os.getenv('src_vars_dict'))
     product           = os.getenv('product')
     dir_ts_workaround = os.getenv('dirTSWorkaround')
     ens_mem           = os.getenv('ens_mem')
@@ -324,6 +340,7 @@ def remap():
     logger.info("    current chunk: %s", current_chunk)
     logger.info("    components: %s", components)
     logger.info("    yaml config: %s", yaml_config)
+    logger.info("    source and var list: %s", src_vars_dict)
     logger.info("    product: %s", product)
     if dir_ts_workaround is not None:
         logger.info("    dirTSWorkaround: %s", dir_ts_workaround)
@@ -462,7 +479,7 @@ def remap():
 
                             ## VARIABLE INFORMATION for requested source
                             # Note: variable filtering not done for offline static diagnostics
-                            v = get_variables(comp_info, product, s)
+                            v = get_variables(comp_info, product, s, src_vars_dict)
 
                             files = search_files(product = product,
                                                  var = v,

--- a/app/remap-pp-components/t/test_remap-pp-components.py
+++ b/app/remap-pp-components/t/test_remap-pp-components.py
@@ -62,7 +62,8 @@ os.environ['product'] = PRODUCT
 os.environ['dirTSWorkaround'] = "1"
 os.environ['COPY_TOOL'] = COPY_TOOL
 os.environ['yaml_config'] = str(YAML_EX)
-os.environ['src_vars_dict'] = "{'atmos_scalar': ['co2mass'], 'atmos_static_scalar': ['bk']}"
+#os.environ['src_vars_dict'] = "{'atmos_scalar': ['co2mass'], 'atmos_static_scalar': ['bk']}"
+os.environ['src_vars_dict'] = "{'atmos_scalar': 'all', 'atmos_static_scalar': 'all'}"
 
 # Set up input directory (location previously made in flow.cylc workflow)
 ncgen_native_out = Path(REMAP_IN) / NATIVE_GRID / COMPOUT / FREQ / CHUNK
@@ -330,6 +331,7 @@ def test_remap_variable_filtering(capfd, monkeypatch):
 
     # Specify environment variables for just this test
     monkeypatch.setenv('components', "atmos_scalar_test_vars")
+    monkeypatch.setenv('src_vars_dict', "{'atmos_scalar': ['co2mass'], 'atmos_static_scalar': ['bk']}")
 
     # run script
     try:
@@ -338,13 +340,12 @@ def test_remap_variable_filtering(capfd, monkeypatch):
         assert False
 
     # Check for
-    # 1. creation of output directory structre,
+    # 1. creation of output directory structure
     # 2. link to nc file in output location
     assert all([Path(f"{REMAP_OUT}/atmos_scalar_test_vars/{PRODUCT}/monthly/5yr").exists(),
                 Path(f"{REMAP_OUT}/atmos_scalar_test_vars/{PRODUCT}/monthly/5yr/{DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
 
-@pytest.mark.skip(reason='test')
 def test_remap_static_variable_filtering(capfd, monkeypatch):
     """
     Test variable filtering capabilties
@@ -357,6 +358,7 @@ def test_remap_static_variable_filtering(capfd, monkeypatch):
     monkeypatch.setenv('product', "static")
     monkeypatch.setenv('dirTSWorkaround', "")
     monkeypatch.setenv('components', "atmos_scalar_test_vars")
+    monkeypatch.setenv('src_vars_dict', "{'atmos_scalar': ['co2mass'], 'atmos_static_scalar': ['bk']}")
 
     Path(os.getenv("outputDir")).mkdir(parents=True,exist_ok=True)
 
@@ -373,8 +375,7 @@ def test_remap_static_variable_filtering(capfd, monkeypatch):
                 Path(f"{os.getenv('outputDir')}/atmos_scalar_test_vars/{STATIC_FREQ}/{STATIC_CHUNK}/{STATIC_DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
  
-#@pytest.mark.xfail
-@pytest.mark.skip(reason='test')
+@pytest.mark.xfail
 def test_remap_variable_filtering_fail(capfd, monkeypatch):
     """
     Test failure of variable filtering capabilties when
@@ -382,12 +383,12 @@ def test_remap_variable_filtering_fail(capfd, monkeypatch):
     """
     # Specify environment variables for just this test
     monkeypatch.setenv('components', "atmos_scalar_test_vars_fail")
+    monkeypatch.setenv('src_vars_dict', "{'atmos_scalar': ['co2mass', 'no_var'], 'atmos_static_scalar': ['atmos_static_scalar']}")
 
     # run script
     remap()
 
-#@pytest.mark.xfail
-@pytest.mark.skip(reason='test')
+@pytest.mark.xfail
 def test_remap_static_variable_filtering_fail(capfd, monkeypatch):
     """
     Test failure of variable filtering capabilties for statics
@@ -399,6 +400,7 @@ def test_remap_static_variable_filtering_fail(capfd, monkeypatch):
     monkeypatch.setenv('product', "static")
     monkeypatch.setenv('dirTSWorkaround', "")
     monkeypatch.setenv('components', "atmos_scalar_static_test_vars_fail")
+    monkeypatch.setenv('src_vars_dict', "{'atmos_scalar': ['all'], 'atmos_static_scalar': ['no_var']}")
 
     # run script
     remap()

--- a/app/remap-pp-components/t/test_remap-pp-components.py
+++ b/app/remap-pp-components/t/test_remap-pp-components.py
@@ -1,8 +1,10 @@
 import os
 import subprocess
 import shutil
+import ast
 from pathlib import Path
 import pytest
+import json
 from remap_pp_components import remap
 
 CWD = os.getcwd()
@@ -60,6 +62,7 @@ os.environ['product'] = PRODUCT
 os.environ['dirTSWorkaround'] = "1"
 os.environ['COPY_TOOL'] = COPY_TOOL
 os.environ['yaml_config'] = str(YAML_EX)
+os.environ['src_vars_dict'] = "{'atmos_scalar': ['co2mass'], 'atmos_static_scalar': ['bk']}"
 
 # Set up input directory (location previously made in flow.cylc workflow)
 ncgen_native_out = Path(REMAP_IN) / NATIVE_GRID / COMPOUT / FREQ / CHUNK
@@ -165,7 +168,7 @@ def test_remap_pp_components(capfd):
                 Path(f"{REMAP_OUT}/{COMPOUT}/{PRODUCT}/monthly/5yr/{DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
 
-## Pytest utilizes mokeypatch fixture which can help set/delete attributes, environments, etc.
+## Pytest utilizes monkeypatch fixture which can help set/delete attributes, environments, etc.
 ## monkeypatch.setenv() used to set/reset specific envrionment variables in each test, 
 ## without resetting them for all tests or the proceeding test (i.e. - wouldn't effect 
 ## other test's envrionment variables defined)
@@ -341,6 +344,7 @@ def test_remap_variable_filtering(capfd, monkeypatch):
                 Path(f"{REMAP_OUT}/atmos_scalar_test_vars/{PRODUCT}/monthly/5yr/{DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
 
+@pytest.mark.skip(reason='test')
 def test_remap_static_variable_filtering(capfd, monkeypatch):
     """
     Test variable filtering capabilties
@@ -369,7 +373,8 @@ def test_remap_static_variable_filtering(capfd, monkeypatch):
                 Path(f"{os.getenv('outputDir')}/atmos_scalar_test_vars/{STATIC_FREQ}/{STATIC_CHUNK}/{STATIC_DATA_FILE_NC}").exists()])
     out, err = capfd.readouterr()
  
-@pytest.mark.xfail
+#@pytest.mark.xfail
+@pytest.mark.skip(reason='test')
 def test_remap_variable_filtering_fail(capfd, monkeypatch):
     """
     Test failure of variable filtering capabilties when
@@ -381,7 +386,8 @@ def test_remap_variable_filtering_fail(capfd, monkeypatch):
     # run script
     remap()
 
-@pytest.mark.xfail
+#@pytest.mark.xfail
+@pytest.mark.skip(reason='test')
 def test_remap_static_variable_filtering_fail(capfd, monkeypatch):
     """
     Test failure of variable filtering capabilties for statics

--- a/app/remap-pp-components/test-data/yaml_ex.yaml
+++ b/app/remap-pp-components/test-data/yaml_ex.yaml
@@ -10,6 +10,7 @@ postprocess:
       static: 
       - source: "atmos_static_cmip"
       postprocess_on: False
+
     - type: "atmos_scalar"
       sources:
         - history_file: "atmos_scalar"
@@ -33,7 +34,7 @@ postprocess:
     - type: "atmos_scalar_test_vars_fail"
       sources:
         - history_file: "atmos_scalar"
-          variables: ["no_var"]
+          variables: ["co2mass", "no_var"]
       inputRealm: "atmos"
       static:
         - source: "atmos_static_scalar"
@@ -46,5 +47,5 @@ postprocess:
       inputRealm: "atmos"
       static:
         - source: "atmos_static_scalar"
-          variables: ["bk", "no_var"]
+          variables: ["no_var"]
       postprocess_on: True

--- a/flow.cylc
+++ b/flow.cylc
@@ -27,6 +27,9 @@
 {# Retrieve active pp components from the yaml #}
 {% set PP_COMPONENTS = YAML | get_components %}
 
+{# Retrieve defined variables associated with active pp components from the yaml in a dictionary #}
+{% set SRC_VARS = YAML | get_variables(PP_COMPONENTS) %}
+
 [meta]
     title = "Postprocessing Example 1"
     description = """
@@ -624,6 +627,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         script = rose task-run --verbose --app-key split-netcdf
         [[[environment]]]
             date = $CYLC_TASK_CYCLE_POINT
+            src_vars_dict = {{ SRC_VARS }}
 
 {% if DO_NATIVE %}
     [[SPLIT-NETCDF-NATIVE]]
@@ -719,6 +723,7 @@ rename-split-to-pp-regrid<regrid_static> => remap-pp-components-static => combin
         [[[environment]]]
             components = $CYLC_TASK_PARAM_component
             yaml_config = {{ YAML }}
+            src_vars_dict = {{ SRC_VARS }}
 
     [[REMAP-PP-COMPONENTS-TS]]
         inherit = REMAP-PP-COMPONENTS


### PR DESCRIPTION
Purpose:
Multiple tasks in the workflow conduct some kind of variable filtering. I have written a function in remap-pp-components that read/parses the yaml config to get these variables. This function can be applied to those other tasks, with a little editing.

This PR:
- creates Jinjafilter to save variables (if defined) associated with each source in a dictionary in flow.cylc
Example output:
```
{atmos: 'all', atmos2: ['vars'], atmos3: 'all'}
```
- then tasks that do variable filtering will read in this dictionary, go through `key:value` pairs, and find the variable info associated with a source it is looking at