### PR TITLE
WF TESTING: remove `app/regrid_xy` test calls in CI/CD

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -41,15 +41,6 @@ jobs:
              pylint -v ; \
              cd - ;
 
-      - name: in fre-workflows environment, regrid-xy pytest and pylint
-        continue-on-error: true
-        run: |
-          # pytest unittests for regrid-xy
-          cd app/regrid-xy && \
-             pytest -v -v -rx --cov=regrid_xy ./t ; \
-             pylint -v ; \
-             cd - ;
-
       - name: in fre-workflows environment, make-timeseries pytest and pylint
         continue-on-error: true
         run: |


### PR DESCRIPTION
remove call to non-existent regrid_xy app in fre-workflows workflow.

replaced formally with [`fre app regrid`](https://github.com/NOAA-GFDL/fre-cli/tree/main/fre/app/regrid_xy)