### PR TITLE
118.address workflow issues

### DIFF
--- a/.github/workflows/create_test_conda_env.yml
+++ b/.github/workflows/create_test_conda_env.yml
@@ -68,5 +68,5 @@ jobs:
         continue-on-error: false
         run: |
           cd Jinja2Filters && \
-            pytest -v ; \
+            pytest -v ./tests ; \
             cd - ;

--- a/Jinja2Filters/legacy_date_conversions.py
+++ b/Jinja2Filters/legacy_date_conversions.py
@@ -1,0 +1,50 @@
+import re
+
+def legacy_date_conversions():
+    """This is kludge to pass cylc processing."""
+    raise Exception("This is not a usable custom filter.")
+
+def convert_iso_duration_to_bronx_freq(duration):
+    """Convert ISO8601 duration to Bronx-style frequency."""
+
+    lookup = {
+        'P1Y': 'annual',
+        'P1M': 'monthly',
+        'P3M': 'seasonal',
+        'P1D': 'daily',
+        'PT120H': '120hr',
+        'PT12H': '12hr',
+        'PT8H': '8hr',
+        'PT6H': '6hr',
+        'PT4H': '4hr',
+        'PT3H': '3hr',
+        'PT2H': '2hr',
+        'PT1H': 'hourly',
+        'PT30M': '30min'
+    }
+
+    try:
+        return(lookup[duration])
+    except KeyError:
+        print(f"ERROR: Conversion of ISO duration '{duration}' to Bronx-style frequency not known")
+        raise
+
+def convert_iso_duration_to_bronx_chunk(duration):
+    """Convert ISO8601 duration to Bronx-style timeseries chunk."""
+
+    # need to convert to string
+    if isinstance(duration, str):
+        duration_str = duration
+    else:
+        duration_str = str(duration)
+
+    match_obj = re.match('^P([0-9]+)Y$', duration_str)
+    if match_obj:
+        return(match_obj.group(1) + 'yr')
+    match_obj = re.match('^P([0-9]+)M$', duration_str)
+    if match_obj:
+        return(match_obj.group(1) + 'mo')
+    raise Exception(f"Conversion of ISO duration '{duration}' to Bronx-style timeseries chunk not known")
+
+#print(convert_iso_duration_to_bronx_freq('PT30M'))
+#print(convert_iso_duration_to_bronx_chunk('P2D'))

--- a/Jinja2Filters/tests/form_remap_dep_test.py
+++ b/Jinja2Filters/tests/form_remap_dep_test.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from . import form_remap_dep
+from Jinja2Filters import form_remap_dep
 
 @pytest.fixture()
 def sample_yaml(tmp_path):

--- a/Jinja2Filters/tests/form_task_parameters_test.py
+++ b/Jinja2Filters/tests/form_task_parameters_test.py
@@ -1,6 +1,6 @@
 import pytest
 import yaml
-from . import form_task_parameters
+from Jinja2Filters import form_task_parameters
 
 @pytest.fixture()
 def yaml_file(tmp_path):

--- a/Jinja2Filters/tests/get_components_test.py
+++ b/Jinja2Filters/tests/get_components_test.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 import metomi.isodatetime.parsers
-from . import get_components
+from Jinja2Filters import get_components
 
 CONFIG = {'postprocess': {'components': [{'postprocess_on': True, 'type': 'comp1'},
                                        {'postprocess_on': True, 'type': 'comp2'},

--- a/Jinja2Filters/tests/iter_chunks_test.py
+++ b/Jinja2Filters/tests/iter_chunks_test.py
@@ -1,7 +1,7 @@
 import pytest
 import metomi.isodatetime
 from metomi.isodatetime.parsers import DurationParser, TimePointParser
-from . import iter_chunks
+from Jinja2Filters import iter_chunks
 
 duration_parser = DurationParser()
 time_parser = TimePointParser(default_to_unknown_time_zone=True)

--- a/Jinja2Filters/tests/subtract_durations_test.py
+++ b/Jinja2Filters/tests/subtract_durations_test.py
@@ -1,6 +1,6 @@
 import pytest
 import metomi.isodatetime.parsers
-from . import subtract_durations
+from Jinja2Filters import subtract_durations
 
 @pytest.mark.parametrize("minuend, subtrahend, difference",
     [('P10D', 'P9D', 'P1D'),

--- a/flow.cylc
+++ b/flow.cylc
@@ -13,6 +13,11 @@
 {# (Probably, we should use similar mechanisms where sensible, e.g. for shared items among workflows)              #}
 {% set SITE = SITE %}
 
+{# Setting STALL_TIMEOUT here gives the ability to override the value if necessary #}
+{# A use case for overriding this value is exhibited in the fre-workflows pipeline test_cloud_runner.yaml #}
+{# In this pipeline, the stall timeout will be 0 in order for the workflow to immediately abort is stalled #}
+{% set STALL_TIMEOUT = P1W %}
+
 {# Set ANALYSIS_START and ANALYSIS_STOP if they do not exist #}
 {% if ANALYSIS_START is not defined %}
     {% set ANALYSIS_START = PP_START %}
@@ -46,7 +51,7 @@
     [[events]]
         # When the stall timeout is reached, a stalled workflow will exit
         # and remove the /xtmp working directory.
-        stall timeout = P1W
+        stall timeout = {{ STALL_TIMEOUT }}
 
 [task parameters]
 {# The task parameters (except for component) depend on configuration in Rose apps,                            #}

--- a/flow.cylc
+++ b/flow.cylc
@@ -13,7 +13,7 @@
 {# (Probably, we should use similar mechanisms where sensible, e.g. for shared items among workflows)              #}
 {% set SITE = SITE %}
 
-{# Setting STALL_TIMEOUT here gives the ability to override the value if necessary #}
+{# Setting STALL_TIMEOUT here provides the ability to override the value if necessary #}
 {# A use case for overriding this value is exhibited in the fre-workflows pipeline test_cloud_runner.yaml #}
 {# In this pipeline, the stall timeout will be 0 in order for the workflow to immediately abort is stalled #}
 {% set STALL_TIMEOUT = P1W %}

--- a/flow.cylc
+++ b/flow.cylc
@@ -16,7 +16,9 @@
 {# Setting STALL_TIMEOUT here provides the ability to override the value if necessary #}
 {# A use case for overriding this value is exhibited in the fre-workflows pipeline test_cloud_runner.yaml #}
 {# In this pipeline, the stall timeout will be 0 in order for the workflow to immediately abort is stalled #}
-{% set STALL_TIMEOUT = P1W %}
+{% if STALL_TIMEOUT is not defined %}
+    {% set STALL_TIMEOUT = P1W %}
+{% endif %}
 
 {# Set ANALYSIS_START and ANALYSIS_STOP if they do not exist #}
 {% if ANALYSIS_START is not defined %}

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -69,7 +69,7 @@
 {% endif %}
 
     [[SPLIT-NETCDF]]
-        pre_script = module load fre/{{ FRE_VERSION }} && mkdir -p $outputDir
+        pre-script = module load fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[RENAME-SPLIT-TO-PP]]
         pre-script = module load netcdf-c cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir


### PR DESCRIPTION
Addresses issue #118:
- fixes Jinja2Filter relative import error
- fixes reference to deleted Jinja2Filter `legacy_date_conversion.py`
- fixes `pre_script` to `pre-script` for split-netcdf task in ppan.cylc
- groups Jinja2Filter tests together
- defined Jinja2 variable `STALL_TIMEOUT` - can be overwritten if needed (in ppp-container-runner pipeline)