### PR TITLE
Fix STALL_TIMEOUT value

### DIFF
--- a/flow.cylc
+++ b/flow.cylc
@@ -17,7 +17,7 @@
 {# A use case for overriding this value is exhibited in the fre-workflows pipeline test_cloud_runner.yaml #}
 {# In this pipeline, the stall timeout will be 0 in order for the workflow to immediately abort is stalled #}
 {% if STALL_TIMEOUT is not defined %}
-    {% set STALL_TIMEOUT = P1W %}
+    {% set STALL_TIMEOUT = "P1W" %}
 {% endif %}
 
 {# Set ANALYSIS_START and ANALYSIS_STOP if they do not exist #}


### PR DESCRIPTION
Currently, there is a `fre pp run` error regarding the `STALL_TIMEOUT` value:
```
INFO - Extracting job.sh to /home/Mikyung.Lee/cylc-
	run/c96L65_am5f10d9r0_amip__gfdl.ncrc5-intel23-classic__prod-
	openmp/.service/etc/job.sh
2025-08-27T08:50:57-04:00 INFO - Workflow: c96L65_am5f10d9r0_amip__gfdl.ncrc5-intel23-classic__prod-openmp
2025-08-27T08:50:58-04:00 ERROR - Workflow shutting down - Jinja2Error: 'P1W' is undefined
	File /home/Mikyung.Lee/cylc-run/c96L65_am5f10d9r0_amip__gfdl.ncrc5-intel23-classic__prod-openmp/flow.cylc
      	[[events]]
          	# When the stall timeout is reached, a stalled workflow will exit
          	# and remove the /xtmp working directory.
          	stall timeout = {{ STALL_TIMEOUT }}   <-- UndefinedError
ERROR:cylc:Workflow shutting down - Jinja2Error: 'P1W' is undefined
File /home/Mikyung.Lee/cylc-run/c96L65_am5f10d9r0_amip__gfdl.ncrc5-intel23-classic__prod-openmp/flow.cylc
  	[[events]]
      	# When the stall timeout is reached, a stalled workflow will exit
      	# and remove the /xtmp working directory.
      	stall timeout = {{ STALL_TIMEOUT }}	<-- UndefinedError
ERROR: ERROR: command terminated by signal 1: gsissh -n an007 env CYLC_VERSION=8.4.1 CYLC_ENV_NAME=cylc-8.4 bash --login -c ''"'"'exec "$0" "$@"'"'"'' /home/fms/local/opt/cylc/bin/cylc play c96L65_am5f10d9r0_amip__gfdl.ncrc5-intel23-classic__prod-openmp --host=localhost --color=always
```

Solution: It seems the `STALL_TIMEOUT` value needs to be in quotes in order to be recognized/defined correctly. 