### PR TITLE
Cleanup `data_lineage` and adjust `ppp` workflow model yaml

### DIFF
--- a/README-developers.md
+++ b/README-developers.md
@@ -133,7 +133,7 @@ after checking it out with a fre pp checkout:
 > ls 
 app/	       environment.yml	       etc/		       Jinja2Filters/  pytest.ini	     README-portability.md    site/
 bin/	       envs/		       flow.cylc	       lib/	       README-developers.md  README_using_fre-cli.md  tests/
-data_lineage/  ESM4.5_candidateA.yaml  generic-global-config/  meta/	       README.md	     rose-suite.conf
+ESM4.5_candidateA.yaml  generic-global-config/  meta/	       README.md	     rose-suite.conf
 > emacs site/ppan.cylc
 ```
 

--- a/app/combine-statics/bin/combine-statics
+++ b/app/combine-statics/bin/combine-statics
@@ -24,14 +24,6 @@ if [[ ! -d $outputDir ]]; then
     exit 1
 fi
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
-
 cd $inputDir
 
 for comp in $(ls); do
@@ -47,55 +39,8 @@ for comp in $(ls); do
 #        echo "$(ls $outputDir/$comp)"
 #    fi
 
-    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-        data_lineage_in_dir=$inputDir/$comp/P0Y/P0Y
-        data_lineage_out_dir=$outputDir/$comp
-
-        start_time=$(date +%s)
-
-        for input_file in *; do 
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $data_lineage_in_dir/$input_file)
-            export input_file_list="${input_file_list}$input_file $hash_val,"
-            echo "[DATA LINEAGE] Added $input_file to input list with hash_val: $hash_val"
-        done
-
-        hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.HashGen $data_lineage_out_dir/$comp.static.nc)
-        export output_file_list="${output_file_list}$comp.static.nc $hash_val,"
-        echo "[DATA LINEAGE] Added $comp.static.nc to output list with hash_val: $hash_val"
-
-        end_time=$(date +%s)
-        duration=$((end_time - start_time))
-        echo "Time spent hashing and creating both file lists: $duration seconds"
-    fi
-
     popd
 done
-
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-    epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$data_lineage_in_dir/"
-    echo "[DATA LINEAGE] Annotated $data_lineage_in_dir/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-    epmt -v annotate EPMT_DATA_LINEAGE_OUT_PATH="$data_lineage_out_dir/"
-    echo "[DATA LINEAGE] Annotated $data_lineage_out_dir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
-fi
 
 echo Natural end of the static combining
 exit 0

--- a/app/combine-timeavgs/bin/combine-timeavgs
+++ b/app/combine-timeavgs/bin/combine-timeavgs
@@ -55,13 +55,7 @@ if [[ ! -d $outputDir ]]; then
     exit 1
 fi
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
+
 
 # Exit early, with appearence of success, if the component directory does not exist
 # This means the make-timeavgs task did not work, which almost certainly means that
@@ -107,24 +101,7 @@ for freq in $(ls); do
         fi
         cdo -O splitmon $component.$dates.nc $outputDir/$subdir/$component.$dates.
         
-        if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunk
-            output_dir_path=$outputDir/$subdir
-            
-            start_time=$(date +%s)
 
-            for output_file in "$outputDir/$subdir/$component.$dates."*; do
-                basename=$(basename $output_file)
-                hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                -m data_lineage.bloomfilter.HashGen $output_file)
-                export output_file_list="${output_file_list}$basename $hash_val,"
-                echo "[DATA LINEAGE] Added $basename to output list with hash_val: $hash_val"
-            done
-
-            end_time=$(date +%s)
-            duration=$((end_time - start_time))
-            echo "Time spent hashing and creating the file list: $duration seconds"
-        fi
 
     elif [[ $freq == P1Y ]]; then
         if ! cdo -O merge $component.$dates.*.nc $outputDir/$subdir/$component.$dates.ann.nc; then
@@ -135,63 +112,16 @@ for freq in $(ls); do
             done
         fi
 
-        if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            input_dir_path=$inputDir/$component/$freq/$currentChunk
-            output_dir_path=$outputDir/$subdir
-            output_file=$component.$dates.ann.nc
 
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $output_dir_path/$output_file)
-            export output_file_list="${output_file_list}$output_file $hash_val,"
-            echo "[DATA LINEAGE] Added $output_file to output list with hash_val: $hash_val"
-        fi
     else
         echo "Error: frequency $freq not supported"
         exit 2
     fi
 
-    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-        epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$input_dir_path/"
-        echo "[DATA LINEAGE] Annotated $input_dir_path/ to EPMT_DATA_LINEAGE_IN_PATH"
-        
-        epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$output_dir_path/"
-        echo "[DATA LINEAGE] Annotated $output_dir_path/ EPMT_DATA_LINEAGE_OUT_PATH" 
 
-        start_time=$(date +%s)
-
-        for file in $component.$dates.*.nc; do
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $input_dir_path/$file)
-            export input_file_list="${input_file_list}$file $hash_val,"
-            echo "[DATA LINEAGE] Added $file to input list with hash_val: $hash_val"
-        done
-
-        end_time=$(date +%s)
-        duration=$((end_time - start_time))
-        echo "Time spent hashing and creating the file list: $duration seconds"
-
-    fi
 
     popd
 done
-
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
-fi
 
 echo Natural end of the timeavg combining
 exit 0

--- a/app/make-timeavgs/bin/make-timeavgs
+++ b/app/make-timeavgs/bin/make-timeavgs
@@ -3,7 +3,7 @@ set -euo pipefail
 set -x
 
 #
-# use fre-python-tools generate_time_average module to average history files 
+# use fre app gen-time-averages module to average history files 
 #
 
 echo Arguments:

--- a/app/make-timeavgs/bin/make-timeavgs
+++ b/app/make-timeavgs/bin/make-timeavgs
@@ -16,13 +16,7 @@ echo Utilities:
 type cylc
 type generate-time-averages
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
+
 
 #this probably shouldnt be a substitute for a proper "find" command...
 echo ""
@@ -80,18 +74,7 @@ for dir in ${dirs[@]}; do
         # and include only one year if a one-year interval
         basename=$(basename $file)
 
-        if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            
-            input_dir_path=$(dirname $file)
 
-            epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$input_dir_path/"
-            echo "[DATA LINEAGE] Annotated $input_dir_path/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $file)
-            export input_file_list="${input_file_list}$basename $hash_val,"
-            echo "[DATA LINEAGE] Added $basename to input list with hash_val: $hash_val"
-        fi
 
         date1=$(echo $basename | cut -d. -f2 | cut -d- -f1)
         date2=$(echo $basename | cut -d. -f2 | cut -d- -f2)
@@ -131,37 +114,12 @@ for dir in ${dirs[@]}; do
             exit $?
         fi
 
-        if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
 
-            epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$output_dir/"
-            echo "[DATA LINEAGE] Annotated $output_dir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $output_dir/$newfile)
-            export output_file_list="${output_file_list}$newfile $hash_val,"
-            echo "[DATA LINEAGE] Added $newfile to output list with hash_val: $hash_val"
-        fi
 
 	done
 	
 done
 
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
 
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
-fi
 
 exit 0

--- a/app/make-timeavgs/bin/make-timeavgs
+++ b/app/make-timeavgs/bin/make-timeavgs
@@ -14,7 +14,6 @@ echo "    interval: $interval"
 echo "    use subdirs: ${use_subdirs:=}"
 echo Utilities:
 type cylc
-type generate-time-averages
 
 
 
@@ -106,7 +105,7 @@ for dir in ${dirs[@]}; do
             output_dir=$outputDir/$component/$file_freq/$interval
         fi
         mkdir -p $output_dir
-        cmd="generate-time-averages -p cdo -a $tool_args ${file} ${output_dir}/$newfile"
+        cmd="fre -vv app gen-time-averages -p cdo -a $tool_args -i ${file} -o ${output_dir}/${newfile}"
         echo "---DEBUG--- to run: $cmd"
 		
 		if ! $cmd; then

--- a/app/make-timeseries/bin/make-timeseries
+++ b/app/make-timeseries/bin/make-timeseries
@@ -63,55 +63,20 @@ function process_timeseries {
             d1=$(echo ${files[0]} | cut -d. -f 2 | cut -d- -f 1)
             d2=$(echo ${files[-1]} | cut -d. -f 2 | cut -d- -f 2)
 
-            # If processing subdirectories, add the subdir (e.g. "1deg") above the component level
-            if [[ $use_subdirs ]]; then
-                data_lineage_in_dir=$subdir/$component/$freq/$chunk
-                data_lineage_out_dir=$subdir/$component/$freq/$outputChunk
-                newdir=$outputDir/$subdir/$component/$freq/$outputChunk
-            else
-                data_lineage_in_dir=$component/$freq/$chunk
-                data_lineage_out_dir=$component/$freq/$outputChunk
-                newdir=$outputDir/$component/$freq/$outputChunk
-            fi
-
             # create timeseries
             mkdir -p $newdir
             if [[ $is_tiled ]]; then
                 for (( tile=1; tile <= 6; ++tile )); do
                     newfile=$component.$d1-$d2.$var.tile$tile.nc
                     tiled_files=$(echo ${files[@]} | sed -e s/tile1/tile$tile/g)
-                    
-                    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                        for input_file in $tiled_files; do
-                            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                            -m data_lineage.bloomfilter.HashGen $inputDir/$data_lineage_in_dir/$input_file)
-                            export input_file_list="${input_file_list}$data_lineage_in_dir/$input_file $hash_val,"
-                            echo "[DATA LINEAGE] Added $data_lineage_in_dir/$input_file to input list with hash_val: $hash_val"
-                        done
-                    fi
 
                     cdo --history -O mergetime $tiled_files $newdir/$newfile
                     fre -v pp ppval --path $newdir/$newfile
                 done
             else
-                if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                    for input_file in ${files[@]}; do
-                        hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                        -m data_lineage.bloomfilter.HashGen $inputDir/$data_lineage_in_dir/$input_file)
-                        export input_file_list="${input_file_list}$data_lineage_in_dir/$input_file $hash_val,"
-                        echo "[DATA LINEAGE] Added $data_lineage_in_dir/$input_file to input list with hash_val: $hash_val"
-                    done
-                fi
                 newfile=$component.$d1-$d2.$var.nc
                 cdo --history -O mergetime ${files[@]} $newdir/$newfile
                 fre -v pp ppval --path $newdir/$newfile
-            fi
-
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                -m data_lineage.bloomfilter.HashGen $newdir/$newfile)
-                export output_file_list="${output_file_list}$data_lineage_out_dir/$newfile $hash_val,"
-                echo "[DATA LINEAGE] Added $data_lineage_out_dir/$newfile to output list with hash_val: $hash_val"
             fi
 
             did_something=1
@@ -167,14 +132,6 @@ if [[ ! -d $outputDir ]]; then
     exit 1
 fi
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
-
 # remove trailing Z to allow string comparison later
 begin=${begin%Z}
 end=${end%Z}
@@ -196,31 +153,6 @@ if [[ $use_subdirs ]]; then
 else
     cd $component
     process_timeseries
-fi
-
-
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-    epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/"
-    echo -e "\n[COLE] annotated $inputDir to EPMT_DATA_LINEAGE_IN_PATH"
-
-    epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/"
-    echo -e  "\n[COLE] annotated $outputDir to EPMT_DATA_LINEAGE_OUT_PATH"
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
 fi
 
 if [[ -n $did_something ]]; then

--- a/app/make-timeseries/bin/make-timeseries
+++ b/app/make-timeseries/bin/make-timeseries
@@ -63,6 +63,13 @@ function process_timeseries {
             d1=$(echo ${files[0]} | cut -d. -f 2 | cut -d- -f 1)
             d2=$(echo ${files[-1]} | cut -d. -f 2 | cut -d- -f 2)
 
+            # If processing subdirectories, add the subdir (e.g. "1deg") above the component level
+            if [[ $use_subdirs ]]; then
+                newdir=$outputDir/$subdir/$component/$freq/$outputChunk
+            else
+                newdir=$outputDir/$component/$freq/$outputChunk
+            fi
+
             # create timeseries
             mkdir -p $newdir
             if [[ $is_tiled ]]; then

--- a/app/mask-atmos-plevel/bin/mask-atmos-plevel
+++ b/app/mask-atmos-plevel/bin/mask-atmos-plevel
@@ -19,13 +19,7 @@ if [[ ! -d $inputDir ]]; then
     exit 1
 fi
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
+
 
 cd $inputDir
 
@@ -34,49 +28,17 @@ for file in $(find . -maxdepth 1 \( -name "*.$component.nc" -o -name "*.$compone
     # Remove the './' prefix from file
     file="${file#./}"
 
-    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
-        hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.HashGen $inputDir/$file)
-        export input_file_list="${input_file_list}$file $hash_val,"
-        echo "[DATA LINEAGE] Added $file to input list with hash_val: $hash_val"
-    fi
+
 
     refine_Atmos_no_redux.py $file -o $file.masked -p $file
     if [[ -f $file.masked ]]; then
         mv -f $file.masked $file
         echo "Updated '$file'"
     fi
-    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
-        hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.HashGen $inputDir/$file)
-        export output_file_list="${output_file_list}$file $hash_val,"
-        echo "[DATA LINEAGE] Added $file to output list with hash_val: $hash_val"
-    fi
+
 done
 
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
 
-    epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/"
-    echo "[DATA LINEAGE] Annotated $inputDir/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-    epmt -v annotate EPMT_DATA_LINEAGE_OUT_PATH="$inputDir/"
-    echo "[DATA LINEAGE] Annotated $inputDir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
-fi 
 
 echo Natural end of the atmos plevel masking
 exit 0

--- a/app/rename-split-to-pp/bin/rename-split-to-pp
+++ b/app/rename-split-to-pp/bin/rename-split-to-pp
@@ -150,43 +150,14 @@ function process_files {
             fi
         fi
 
-        if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-            if [[ $use_subdir_switch ]]; then
-                data_lineage_in_path=$inputDir/$subdir
-            else
-                data_lineage_in_path=$inputDir
-            fi
-            hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-            -m data_lineage.bloomfilter.HashGen $data_lineage_in_path/$file) # Currently hardcoded for only 1 subdir
-            export input_file_list="${input_file_list}$file $hash_val,"
-            echo "[DATA LINEAGE] Added $file to input list with hash_val: $hash_val"
-        fi
+
 
         # If in subdir mode, preserve the subdir
         echo "using subdirs: $use_subdirs"
         if (( $use_subdir_switch )); then
             dir=$outputDir/$subdir/$label/$freq/$chunk
-
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-                epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/$subdir/"
-                echo "[DATA LINEAGE] Annotated $inputDir/$subdir to EPMT_DATA_LINEAGE_IN_PATH"
-
-                epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/$subdir/$label/"
-                echo "[DATA LINEAGE] Annotated $outputDir/$subdir/$label/ to EPMT_DATA_LINEAGE_OUT_PATH"
-            fi
-
         else
             dir=$outputDir/$label/$freq/$chunk
-
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-                epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/"
-                echo "[DATA LINEAGE] Annotated $inputDir/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-                epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/$label/"
-                echo "[DATA LINEAGE] Annotated $outputDir/$label/ to EPMT_DATA_LINEAGE_OUT_PATH"
-            fi
         fi
 
         mkdir -p $dir
@@ -203,23 +174,11 @@ function process_files {
                     if [[ $freq != P0Y ]]; then
                         fre -v pp ppval --path $dir/$newfile
                     fi
-                    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                        hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                        -m data_lineage.bloomfilter.HashGen $dir/$newf)
-                        export output_file_list="${output_file_list}$freq/$chunk/$newf $hash_val,"
-                        echo "[DATA LINEAGE] Added $freq/$chunk/$newf to output list with hash_val: $hash_val"
-                    fi
                 done
             else
                 ln $file $dir/$newfile
                 if [[ $freq != P0Y ]]; then
                         fre -v pp ppval --path $dir/$newfile
-                fi
-                if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                    hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                    -m data_lineage.bloomfilter.HashGen $dir/$newfile)
-                    export output_file_list="${output_file_list}$freq/$chunk/$newfile $hash_val,"
-                    echo "[DATA LINEAGE] Added $freq/$chunk/$newfile to output list with hash_val: $hash_val"
                 fi
             fi
         fi
@@ -258,14 +217,6 @@ if [[ ! -d $outputDir ]]; then
     exit 1
 fi
 
-# Setup PYTHONPATH and io lists for the data lineage tool
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-    export PYTHONPATH=$CYLC_SUITE_DEF_PATH:$PYTHONPATH
-    export input_file_list=
-    export output_file_list=
-    echo "Set PYTHONPATH and created i/o lists"
-fi
-
 # Assumptions:
 # - Format of the file: DATE1.comp.VAR(.tileX).nc
 # - Variable is a static if it does not have a time axis. Otherwise,
@@ -287,14 +238,6 @@ if [[ $use_subdirs == "True" ]]; then
         if [[ $files =~ \* ]]; then
             err No input files
         else
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-                epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/$subdir/"
-                echo -e  "\n[COLE] annotated $inputDir/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-                epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/$subdir/"
-                echo -e  "\n[COLE] annotated $outputDir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-            fi
-
             process_files "$inputDir/$subdir"
         fi
         popd
@@ -311,51 +254,7 @@ else
         exit 1
     fi
 
-    if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-        epmt annotate EPMT_DATA_LINEAGE_IN_PATH="$inputDir/"
-        echo -e  "\n[COLE] annotated $inputDir/ to EPMT_DATA_LINEAGE_IN_PATH"
-
-        epmt annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/"
-        echo -e  "\n[COLE] annotated $outputDir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-    fi
-
     process_files "$inputDir"
-fi
-
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
-fi
-
-if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" = "1" ]; then
-
-    # Annotate to EPMT
-    if [ -n "$input_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${input_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_IN="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated input files to EPMT_LINEAGE_IN"
-    fi
-
-    if [ -n "$output_file_list" ]; then
-        compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-        -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-        epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-        echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-    fi
 fi
 
 echo Natural end of the shard renaming

--- a/flow.cylc
+++ b/flow.cylc
@@ -422,41 +422,6 @@
             fre -v pp histval --warn --history $ptmpDir$historyDir/$(basename -s .tar $file) \
                 --date_string $(cylc cycle-point --template CCYYMMDD)
 
-            # Setup PYTHONPATH and io lists for the data lineage tool
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
-                export PYTHONPATH=$CYLC_WORKFLOW_RUN_DIR:$PYTHONPATH
-                export input_file_list=
-                export output_file_list=
-                echo "Set PYTHONPATH and created i/o lists"
-            fi
-
-            if [ ! -z "${EPMT_DATA_LINEAGE+x}" ] && [ "$EPMT_DATA_LINEAGE" == "1" ]; then
-                outputDir=$CYLC_WORKFLOW_SHARE_DIR/cycle/$CYLC_TASK_CYCLE_POINT/history/native
-
-                start_time=$(date +%s)
-
-                for file in $(ls $outputDir); do
-                    hash_val=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                    -m data_lineage.bloomfilter.HashGen $outputDir/$file)
-                    export output_file_list="${output_file_list}$file $hash_val,"
-                    echo "[DATA LINEAGE] Added $file to output list with hash_val: $hash_val"
-                done
-
-                end_time=$(date +%s)
-                duration=$((end_time - start_time))
-                echo "Time spent hashing and creating the file list: $duration seconds"
-
-                epmt -v annotate EPMT_DATA_LINEAGE_OUT_PATH="$outputDir/"
-                echo "[DATA LINEAGE] Annotated $outputDir/ to EPMT_DATA_LINEAGE_OUT_PATH"
-
-                if [ -n "$output_file_list" ]; then
-                    compressed_bytes=$(/home/Cole.Harvey/.conda/envs/bloom-filter-env/bin/python \
-                    -m data_lineage.bloomfilter.StringCompression "${output_file_list}")
-                    epmt -v annotate EPMT_DATA_LINEAGE_OUT="${compressed_bytes%*,}"
-                    echo "[DATA LINEAGE] Annotated output files to EPMT_LINEAGE_OUT"
-                fi
-            fi
-
             echo "Natural end of the history file staging"
             exit 0
         """

--- a/for_gh_runner/yaml_workflow/model.yaml
+++ b/for_gh_runner/yaml_workflow/model.yaml
@@ -13,8 +13,8 @@ fre_properties:
 
 experiments:
   - name: "test_pp"
+    settings: "settings.yaml"
     pp:
-      - "settings.yaml"
       - "pp1.yaml"
 #    analysis:
 #      - "an1.yaml"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = . data_lineage
+pythonpath = .

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -86,7 +86,7 @@
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[MAKE-TIMEAVGS]]
-        pre-script = mkdir -p $outputDir
+        pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[COMBINE-TIMEAVGS]]
         pre-script = module load cdo nco && mkdir -p $outputDir

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -86,7 +86,7 @@
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[MAKE-TIMEAVGS]]
-        pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
+        pre-script = module load fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[COMBINE-TIMEAVGS]]
         pre-script = module load cdo nco && mkdir -p $outputDir

--- a/site/ppan.cylc
+++ b/site/ppan.cylc
@@ -86,7 +86,7 @@
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[MAKE-TIMEAVGS]]
-        pre-script = module load fre-python-tools && mkdir -p $outputDir
+        pre-script = mkdir -p $outputDir
 
     [[COMBINE-TIMEAVGS]]
         pre-script = module load cdo nco && mkdir -p $outputDir

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -147,7 +147,7 @@
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[MAKE-TIMEAVGS]]
-        pre-script = mkdir -p $outputDir
+        pre-script = module load fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[COMBINE-TIMEAVGS]]
         pre-script = module load cdo nco && mkdir -p $outputDir

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -147,7 +147,7 @@
         pre-script = module load cdo fre/{{ FRE_VERSION }} && mkdir -p $outputDir
 
     [[MAKE-TIMEAVGS]]
-        pre-script = module load fre-python-tools && mkdir -p $outputDir
+        pre-script = mkdir -p $outputDir
 
     [[COMBINE-TIMEAVGS]]
         pre-script = module load cdo nco && mkdir -p $outputDir

--- a/site/ppan_test.cylc
+++ b/site/ppan_test.cylc
@@ -36,8 +36,6 @@
             --comment=xtmp,epmt,fre/{{ FRE_VERSION }}
         [[[environment]]]
             COPY_TOOL=gcp
-            # Uncomment to collect data for the data lineage tool
-            # EPMT_DATA_LINEAGE=1
 
     [[PP-STARTER]]
         env-script = """


### PR DESCRIPTION
- removes the sadly-out-of-date `data_lineage` bits from routines, docs, etc.
- moves the `settings.yaml` out from the `pp` key of the model yaml for `ppp`, and under it's own `settings:` key to address a workflow break from recent updates to `fre-cli`/`gfdl_msd_schemas`
- replaces all remaining instance of `fre-python-tools::generate-time-averages` with `fre app gen-time-averages` calls