### PR TITLE
Create `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Describe your changes
+
+## Issue ticket number and link (if applicable)
+
+## Checklist before requesting a review
+
+- [ ] I ran my code
+- [ ] I tried to make my code readable
+- [ ] I tried to comment my code
+- [ ] I wrote a new test, if applicable
+- [ ] I wrote new instructions/documentation, if applicable
+- [ ] I ran pytest and inspected it's output
+- [ ] I ran pylint and attempted to implement some of it's feedback
+- [ ] No print statements; all user-facing info uses logging module
+
+## Manual Pipeline Run Details
+
+To trigger the manual pipeline:
+1. Go to `Actions` tab
+2. Choose `test_cloud_runner` on left (you should see "This workflow has a workflow_dispatch event trigger.")
+3. Click the dropdown "Run workflow" and choose the fre-workflows and fre-cli branches you want to test
+
+**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**
+- [ ] Yes
+- [ ] No
+
+**Result of manual pipeline run:**
+<!-- Paste relevant logs, output, or a link to the workflow run here -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@
 
 ## Manual Pipeline Run Details
 
+The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes.
+
 To trigger the manual pipeline:
 1. Go to `Actions` tab
 2. Choose `test_cloud_runner` on left (you should see "This workflow has a workflow_dispatch event trigger.")
@@ -25,4 +27,5 @@ To trigger the manual pipeline:
 - [ ] No
 
 **Result of manual pipeline run:**
-<!-- Paste relevant logs, output, or a link to the workflow run here -->
+
+(Paste relevant logs, output, or a link to the workflow run here)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 
 ## Manual Pipeline Run Details
 
-The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes.
+The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes in a full post-processing run.
 
 To trigger the manual pipeline:
 1. Go to `Actions` tab


### PR DESCRIPTION
Adding  a PR template (mostly copied from the fre-cli), including manual pipeline results

Wanted to include this because since the test_cloud_runner has to be manually triggered, I can't make it a required check