### PR TITLE
let pipeline succeed even if `data catalog` fails

### DIFF
--- a/.github/workflows/test_cloud_runner.yml
+++ b/.github/workflows/test_cloud_runner.yml
@@ -203,7 +203,8 @@ jobs:
               exit 2
           fi
 
-      - name: Print data-catalog-final
+      - name: Print data-catalog-final (FAILURE-GUARDED)
+        continue-on-error: true
         run: |
           set +e
           # Successes 


### PR DESCRIPTION
`test_cloud_runner` [runs](https://github.com/NOAA-GFDL/fre-workflows/actions/workflows/test_cloud_runner.yml?query=branch%3Aguard-against-catalog-failure)