### PR TITLE
Update mounted container paths from attached storage on cloud

### DIFF
--- a/.github/workflows/test_cloud_runner.yml
+++ b/.github/workflows/test_cloud_runner.yml
@@ -297,7 +297,8 @@ jobs:
               exit 2
           fi
 
-      - name: Print rename-split-to-pp successes or failures
+      - name: Print rename-split-to-pp successes or failures (FAILURE-GUARDED)
+        continue-on-error: true
         run: |
           set +e
           # Successes 


### PR DESCRIPTION
## Describe your changes
- Re-configuring attached storages on cloud resource (paths changed)
- update container name (includes all of fre-cli, can be used for more than post-processing though that is the specific use case in this repo)
 
## Issue ticket number and link (if applicable)
N/A

## Checklist before requesting a review

- [ ] I ran my code
- [ ] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [ ] No print statements; all user-facing info uses logging module

## Manual Pipeline Run Details
**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**
- [x] Yes
- [ ] No

**Result of manual pipeline run:**

https://github.com/NOAA-GFDL/fre-workflows/actions/runs/21684148861/job/62526730223

**How to trigger the manual pipeline:**

The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes in a full post-processing run.

To trigger the manual pipeline:
1. Follow the link to the `test_cloud_runner` actions tab [here](https://github.com/NOAA-GFDL/fre-workflows/actions/workflows/test_cloud_runner.yml)
    - you should see "This workflow has a workflow_dispatch event trigger"
    
3. Click the dropdown "Run workflow":

    a. If trying to merge from a branch on fre-workflows: choose branch from the first drop down, leave the next 2 inputs blank, and choose the fre-cli branch to test

    b. If trying to merge from a fre-workflows fork: can skip first branch selection, input the fork name (ex: [user]/fre-workflows), input the fork's branch name, and choose the fre-cli branch to test
4. Click "Run workflow"

Note: you may need to reload the page to see your running workflow. 
