### PR TITLE
Have Cylc email the user only if the do_workflow_email switch is set

### DIFF
--- a/flow.cylc
+++ b/flow.cylc
@@ -56,7 +56,9 @@
         # When the stall timeout is reached, a stalled workflow will exit
         # and remove the /xtmp working directory.
         stall timeout = {{ STALL_TIMEOUT }}
+{% if DO_WORKFLOW_EMAIL is defined and DO_WORKFLOW_EMAIL %}
         mail events = startup, shutdown, abort, stall, inactivity timeout, restart timeout
+{% endif %}
 
 [task parameters]
 {# The task parameters (except for component) depend on configuration in Rose apps,                            #}


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link (if applicable)
#224 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [ ] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

## Manual Pipeline Run Details
**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**
- [ ] Yes
- [ ] No

**Result of manual pipeline run:**

(Paste relevant logs, output, or a link to the workflow run here)

**How to trigger the manual pipeline:**

The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes in a full post-processing run.

To trigger the manual pipeline:
1. Follow the link to the `test_cloud_runner` actions tab [here](https://github.com/NOAA-GFDL/fre-workflows/actions/workflows/test_cloud_runner.yml)
    - you should see "This workflow has a workflow_dispatch event trigger"
    
3. Click the dropdown "Run workflow":

    a. If trying to merge from a branch on fre-workflows: choose branch from the first drop down, leave the next 2 inputs blank, and choose the fre-cli branch to test

    b. If trying to merge from a fre-workflows fork: can skip first branch selection, input the fork name (ex: [user]/fre-workflows), input the fork's branch name, and choose the fre-cli branch to test
4. Click "Run workflow"

Note: you may need to reload the page to see your running workflow. 
