### PR TITLE
add 1-hour and 2-hour retries for all tasks except pp-starter

### DIFF
--- a/flow.cylc
+++ b/flow.cylc
@@ -109,8 +109,8 @@
     # Runahead limit specifies the number of cycle points that will spawn ahead of the oldest incomplete task.
     # We don't need it because we specify the final cycle point, and it decreases robustness
     # as it prevents future tasks from running due to a previous failed task.
-    # As runahead limit is required, we will set it to 99999.
-    runahead limit = P99999
+    # As runahead limit is required, we will set it to 999.
+    runahead limit = P999
     [[queues]]
         # Limit the entire workflow to 100 active tasks. Only allow a single cleaning
         # or data-catalog task to run at once, as they can fail if run in parallel.
@@ -289,11 +289,16 @@
 
 [runtime]
     [[root]]
+        # retry all tasks twice- once after an hour, second after two hours
+        execution retry delays = PT1H, PT2H
         [[[environment]]]
             fre_yaml = $CYLC_WORKFLOW_RUN_DIR/{{ YAML }}
 
     [[pp-starter]]
         inherit = PP-STARTER
+        # Note: pp-starter is a fake task and should be rephrased as a proper trigger.
+        # No task retries for this fake task.
+        execution retry delays =
         # NOTE! script must appear *before* [[[enviroment]]] or else
         # the job scripts will have quoting issues
         script = """

--- a/flow.cylc
+++ b/flow.cylc
@@ -22,6 +22,12 @@
     {% set STALL_TIMEOUT = "P1W" %}
 {% endif %}
 
+{# Set default retries unless it is already set by the test pipeline #}
+{# Retry all tasks twice- once after an hour, second after two hours #}
+{% if DEFAULT_RETRIES is not defined %}
+    {% set DEFAULT_RETRIES = "PT1H, PT2H" %}
+{% endif %}
+
 {# Set ANALYSIS_START and ANALYSIS_STOP if they do not exist #}
 {% if ANALYSIS_START is not defined %}
     {% set ANALYSIS_START = PP_START %}
@@ -289,8 +295,7 @@
 
 [runtime]
     [[root]]
-        # retry all tasks twice- once after an hour, second after two hours
-        execution retry delays = PT1H, PT2H
+        execution retry delays = {{ DEFAULT_RETRIES }}
         [[[environment]]]
             fre_yaml = $CYLC_WORKFLOW_RUN_DIR/{{ YAML }}
 

--- a/for_gh_runner/runscript.sh
+++ b/for_gh_runner/runscript.sh
@@ -118,7 +118,8 @@ fre_pp_steps () {
 
     ## RUN
     echo -e "\nRunning the workflow with cylc play ..."
-    cylc play --no-detach --debug -s 'STALL_TIMEOUT="PT0S"' ${name}
+    # set these two jinja variables to disable task retries and set the stall timer to zero
+    cylc play --no-detach --debug -s 'STALL_TIMEOUT="PT0S"' -s 'DEFAULT_RETRIES=""' ${name}
     #check_exit_status "PLAY" # if cylc play fails and this is not commented, log uploading does not work
 
     ## SUMMARY


### PR DESCRIPTION
## Describe your changes
Also, set runahead limit lower due to cylc error. (In Chris's defense, `cylc validate` did not flag the 99999 as too high)

## Issue ticket number and link (if applicable)
#242 #241

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [ ] I wrote a new test, if applicable
- [ ] I wrote new instructions/documentation, if applicable
- [ ] I ran pytest and inspected it's output
- [ ] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

## Manual Pipeline Run Details
**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**
- [ ] Yes
- [ ] No

**Result of manual pipeline run:**

(Paste relevant logs, output, or a link to the workflow run here)

**How to trigger the manual pipeline:**

The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes in a full post-processing run.

To trigger the manual pipeline:
1. Follow the link to the `test_cloud_runner` actions tab [here](https://github.com/NOAA-GFDL/fre-workflows/actions/workflows/test_cloud_runner.yml)
    - you should see "This workflow has a workflow_dispatch event trigger"
    
3. Click the dropdown "Run workflow":

    a. If trying to merge from a branch on fre-workflows: choose branch from the first drop down, leave the next 2 inputs blank, and choose the fre-cli branch to test

    b. If trying to merge from a fre-workflows fork: can skip first branch selection, input the fork name (ex: [user]/fre-workflows), input the fork's branch name, and choose the fre-cli branch to test
4. Click "Run workflow"

Note: you may need to reload the page to see your running workflow. 
