### PR TITLE
postprocess_on is optional and defaults to true

### DIFF
--- a/Jinja2Filters/get_climatology_info.py
+++ b/Jinja2Filters/get_climatology_info.py
@@ -168,14 +168,14 @@ def task_generator(yaml_):
     # Retrieve the pp components
     components = []
     for component in yaml_["postprocess"]["components"]:
-        if component["postprocess_on"] is True:
+        if component.get("postprocess_on", True):
             components.append(component["type"])
 
     # determine pp chunk to use. require the timeaverage interval to be a multiple of pp chunk
     pp_chunks = yaml_["postprocess"]["settings"]["pp_chunks"]
 
     for component in yaml_["postprocess"]["components"]:
-        if not component['postprocess_on']:
+        if not component.get('postprocess_on', True):
             continue
         if 'climatology' in component:
             for item in component['climatology']:

--- a/Jinja2Filters/tests/get_climatology_info_test.py
+++ b/Jinja2Filters/tests/get_climatology_info_test.py
@@ -1,0 +1,51 @@
+import pytest
+import yaml
+from Jinja2Filters import get_climatology_info
+
+CONFIG = {'postprocess': {'components': [{'postprocess_on': True,
+                                           'type': 'comp1',
+                                           'sources': [{'history_file': 'comp1_month'}],
+                                           'climatology': [{'frequency': 'mon', 'interval_years': 2}]},
+                                          {'type': 'comp2',
+                                           'sources': [{'history_file': 'comp2_month'}],
+                                           'climatology': [{'frequency': 'mon', 'interval_years': 2}]},
+                                          {'postprocess_on': False,
+                                           'type': 'comp3',
+                                           'sources': [{'history_file': 'comp3_month'}],
+                                           'climatology': [{'frequency': 'mon', 'interval_years': 2}]}],
+                          'settings': {'pp_chunks': ['P1Y'],
+                                       'history_segment': 'P1Y'},
+                          'switches': {'clean_work': False}}}
+
+
+@pytest.fixture()
+def sample_yaml(tmp_path):
+    """Create sample pp yaml with one component explicitly on, one with
+    postprocess_on omitted (should default to on), and one explicitly off"""
+    temp_dir = tmp_path
+    temp_dir.mkdir(exist_ok=True)
+
+    yaml_file = temp_dir / 'config.yaml'
+    with open(yaml_file, 'w') as file_:
+        yaml.dump(CONFIG, file_)
+
+    yield yaml_file
+
+
+def test_postprocess_on_omitted_defaults_to_on(sample_yaml):
+    """comp1 (explicitly on) and comp2 (postprocess_on omitted) should be
+    included; comp3 (explicitly off) should be excluded"""
+    result = get_climatology_info.get_climatology_info(sample_yaml, 'task-definitions')
+
+    assert 'climo-mon-P2Y_comp1' in result
+    assert 'climo-mon-P2Y_comp2' in result
+    assert 'climo-mon-P2Y_comp3' not in result
+
+
+def test_postprocess_on_omitted_defaults_to_on_graph(sample_yaml):
+    """Same as above, but for the task-graph output"""
+    result = get_climatology_info.get_climatology_info(sample_yaml, 'task-graph')
+
+    assert 'climo-mon-P2Y_comp1' in result
+    assert 'climo-mon-P2Y_comp2' in result
+    assert 'climo-mon-P2Y_comp3' not in result

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = .
+pythonpath = . Jinja2Filters


### PR DESCRIPTION
## Describe your changes
Let postprocess_on default to true, add test, and fix imports to be test-friendly

## Issue ticket number and link (if applicable)
#246 

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

## Manual Pipeline Run Details
**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**
- [ ] Yes
- [ ] No

**Result of manual pipeline run:**

(Paste relevant logs, output, or a link to the workflow run here)

**How to trigger the manual pipeline:**

The `test_cloud_runner` pipeline is not automatically associated as a required check with the PR; it must be triggered to test changes in a full post-processing run.

To trigger the manual pipeline:
1. Follow the link to the `test_cloud_runner` actions tab [here](https://github.com/NOAA-GFDL/fre-workflows/actions/workflows/test_cloud_runner.yml)
    - you should see "This workflow has a workflow_dispatch event trigger"
    
3. Click the dropdown "Run workflow":

    a. If trying to merge from a branch on fre-workflows: choose branch from the first drop down, leave the next 2 inputs blank, and choose the fre-cli branch to test

    b. If trying to merge from a fre-workflows fork: can skip first branch selection, input the fork name (ex: [user]/fre-workflows), input the fork's branch name, and choose the fre-cli branch to test
4. Click "Run workflow"

Note: you may need to reload the page to see your running workflow. 
