### PR TITLE
Rename PPAN sites to reflect EPMT behavior

### DIFF
--- a/flow.cylc
+++ b/flow.cylc
@@ -10,8 +10,8 @@
 {# Jinja code with two braces is printed.                            #}
 
 {# The site-specific file (stored in site/ subdir) is included at the end of this file. When working in the main   #}
-{# branch, the ppan site file should be specified. The ppan site comprises of gfdl specific tools. Other available #}
-{# sites include ppan, gfdl-ws, and generic. The generic.cylc site file is used for a portable flow.cylc.          #}
+{# branch, the ppan_epmt site file should be specified. The ppan_epmt site comprises GFDL-specific tools. Other available #}
+{# sites include ppan_noepmt, gfdl-ws, and generic. The generic.cylc site file is used for a portable flow.cylc.           #}
 {# (Probably, we should use similar mechanisms where sensible, e.g. for shared items among workflows)              #}
 {% set SITE = SITE %}
 
@@ -1040,9 +1040,9 @@
 {% include 'site/' ~ SITE ~ '.cylc' %}
 
 {# this is required for portability should probably only include #}
-{# inherit = <some_task_param> if SITE = ppan_test #}
+{# inherit = <some_task_param> if SITE = ppan_epmt #}
 {# but empty task-family inheritence is inconsequential for now. #}
-{% if SITE != 'ppan_test' %}
+{% if SITE != 'ppan_epmt' %}
     {% if DO_REGRID %}
     [[<regrid>]]
         {% if DO_REGRID_STATIC %}

--- a/for-developers.md
+++ b/for-developers.md
@@ -77,15 +77,16 @@ It serves as a common input argument to many functions, helping uniquely identif
 
 In `cylc`, a platform is usually about selecting a specific set of global configuration values. In `fre-workflows`, it also
 determines which file in `site/` will be included in the primary `flow.cylc` via `Jinja2`. For PPAN, the two relevant
-platform values are `ppan` and `ppan_test`, corresponding to the template files `site/ppan.cylc` and `site/ppan_test.cylc`
-respectively. The platform is chosen based on a `site` configuration value within a `fre` settings `yaml`.
+platform values are `ppan_noepmt` and `ppan_epmt`, corresponding to the template files `site/ppan_noepmt.cylc` and `site/ppan_epmt.cylc`
+respectively. `ppan_epmt` is the default; select `ppan_noepmt` to disable `epmt`. The platform is chosen based on a
+`site` configuration value within a `fre` settings `yaml`.
 
 
-#### `ppan` v. `ppan_test` <a name="sitevaluespecifics"></a>
+#### `ppan_noepmt` v. `ppan_epmt` <a name="sitevaluespecifics"></a>
 
-These two platforms differ in one key field: the `job runner handler`. `site/ppan.cylc` specifies that `cylc`'s default
-`Slurm` job runner handler will be used. `site/ppan_test.cylc` uses a custom version of the `Slurm` job
-runner handler that parses the job script and tags certain operations for tracking via `epmt`. Additionally, `ppan_test`
+These two platforms differ in one key field: the `job runner handler`. `site/ppan_noepmt.cylc` specifies that `cylc`'s default
+`Slurm` job runner handler will be used. `site/ppan_epmt.cylc` uses a custom version of the `Slurm` job
+runner handler that parses the job script and tags certain operations for tracking via `epmt`. Additionally, `ppan_epmt`
 contains `Jinja2` lines that are parsed and ultimately render to a string of annotations that help `epmt` track
 workflow functionality across different workflow settings.
 
@@ -213,7 +214,7 @@ which fre
 module load cylc
 ```
 
-Now, open `site/ppan_test.cylc` with your preferred text editor (or `site/ppan.cylc` to test without `epmt`
+Now, open `site/ppan_epmt.cylc` with your preferred text editor (or `site/ppan_noepmt.cylc` to test without `epmt`
 annotations/tagging), and under `[runtime]`, within the `root` task-family's `init-script`, find the following:
 ```
 [runtime]
@@ -249,12 +250,12 @@ configuration and edit it to comply with system restrictions and enable proper f
 in your `PATH`.
 
 Next, open the `global.cylc` file and confirm the field `use login shell` is set to `true`, then find the `ssh command`
-field and change it to `ssh`. Do this for both the `ppan` and `ppan_test` platform definitions.
+field and change it to `ssh`. Do this for both the `ppan_noepmt` and `ppan_epmt` platform definitions.
 
 You will need to remove the default `cylc` from your `PATH` and include a path to the exact `cylc` within
 your conda environment. To accomplish this, follow the instructions in the previous section [here](#ppanspecifics).
 
-Next, just like in the [previous section](#withcondaandcylc), edit either `ppan.cylc` or `ppan_test.cylc`
+Next, just like in the [previous section](#withcondaandcylc), edit either `ppan_noepmt.cylc` or `ppan_epmt.cylc`
 in `site/` to add your `fre-cli` environment executables to `PATH` for your submitted workflow tasks. This should be the
 last bit of editing you need to do.
 
@@ -317,11 +318,11 @@ Other useful CLI commands for monitoring your workflow progress:
 ## Testing and Verifying `epmt` Functionality <a name="epmttesting"></a>
 
 The `site` variable in `for_gh_runner/yaml_workflow/local_settings.yaml` controls which site configuration is loaded.
-Setting `site='ppan'` runs without `epmt` integration. Setting `site='ppan_test'` enables `epmt` functionality. Namely,
+Setting `site='ppan_noepmt'` runs without `epmt` integration. Setting `site='ppan_epmt'` enables `epmt` functionality. Namely,
 these are per-task metadata annotations, and `papiex` tag insertion for shell calls and processes. The way these two
 functionalities work is slightly different.
 
-The metadata annotations are generated via Jinja2 within `site/ppan_test.cylc`, using available environment variables
+The metadata annotations are generated via Jinja2 within `site/ppan_epmt.cylc`, using available environment variables
 and/or Jinja2 variables to pull and render the tag at runtime. The `papiex` tag insertion is more complex, requiring 
 the use of a custom Slurm `job_runner_handler`. `job_runner_handler`s in `cylc` are classes that manage submission of
 workflow tasks to a batch workload system. See
@@ -338,8 +339,8 @@ the docstrings and comments within the code.
 
 ### Verifying `epmt` Annotations and `papiex` Tags <a name="verifyingepmt"></a>
 
-Running workflows with `epmt` enabled follows the same procedures described in section [4](#configrunppanworkflows), 
-using `ppan_test` instead of `ppan`. After a workflow has at least partially completed, verify that `epmt` data was 
+Running workflows with `epmt` enabled follows the same procedures described in section [4](#configrunppanworkflows),
+using `ppan_epmt` instead of `ppan_noepmt`. After a workflow has at least partially completed, verify that `epmt` data was
 captured. Job success is irrelevant- `epmt` should retrieve the data successfully for near any degree of success/failure. 
 From a workstation, do `module load epmt`, then `epmt python` to open a python shell with `epmt`. You can query job 
 information below by replacing `your_user_here` with your username:
@@ -415,7 +416,7 @@ to the bottom of the workflow template.
 
 **If you are trying to make changes to a workflow template, first consider where the changes should live**, given the
 hierarchy described above. For example, if your changes are so specific to PPAN that the workflow will break everywhere
-else, then those changes belong in both `site/ppan.cylc` and `site/ppan_test.cylc`. If the changes were specific to 
+else, then those changes belong in both `site/ppan_noepmt.cylc` and `site/ppan_epmt.cylc`. If the changes were specific to
 Gaea, they would go in `site/gaea.cylc`, etc. If the changes are truly platform independent, and must be propagated
 to all sites, then the changes should go in `flow.cylc`.
 
@@ -456,7 +457,5 @@ workflow must successfully build an environment and run all unit tests within th
 a manual run of the `test_cloud_runner` workflow is required, as it tests the postprocessing workflow in a fully integrated,
 end-to-end manner. The success of the `test_cloud_runner` workflow must be unconditionally improved from the current version
 of the `main` branch.
-
-
 
 

--- a/for_gh_runner/yaml_workflow/local_settings.yaml
+++ b/for_gh_runner/yaml_workflow/local_settings.yaml
@@ -12,8 +12,8 @@ directories:
 postprocess:
   settings:
     history_segment:         "P1Y"
-    site:                    "ppan"
-#    site:                    "ppan_test"
+    site:                    "ppan_epmt"
+#    site:                    "ppan_noepmt"
     pp_chunks:               [*PP_CHUNK96]
     pp_start:                *EXP_AMIP_START
     pp_stop:                 *EXP_AMIP_END

--- a/global/gfdl_ppan_global.cylc
+++ b/global/gfdl_ppan_global.cylc
@@ -98,7 +98,7 @@
         [[[selection]]]
             method = definition order
         [[[directives]]]
-    [[ppan]]
+    [[ppan_noepmt]]
         job runner = slurm
         hosts = localhost
         install target = localhost
@@ -133,7 +133,7 @@
         [[[selection]]]
             method = random
         [[[directives]]]
-    [[ppan_test]]
+    [[ppan_epmt]]
         job runner = ppan_handler
         hosts = localhost
         cylc path = /home/fms/local/opt/cylc/bin

--- a/lib/python/tests/test_site_names.py
+++ b/lib/python/tests/test_site_names.py
@@ -1,0 +1,24 @@
+"""Regression tests for PPAN site and platform names."""
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).parents[3]
+
+
+def test_ppan_site_names_are_consistent():
+    """The EPMT site is the default and legacy names are fully retired."""
+    epmt_site = REPOSITORY_ROOT / "site" / "ppan_epmt.cylc"
+    noepmt_site = REPOSITORY_ROOT / "site" / "ppan_noepmt.cylc"
+    local_settings = REPOSITORY_ROOT / "for_gh_runner" / "yaml_workflow" / "local_settings.yaml"
+    global_config = REPOSITORY_ROOT / "global" / "gfdl_ppan_global.cylc"
+
+    assert epmt_site.is_file()
+    assert noepmt_site.is_file()
+    assert not (REPOSITORY_ROOT / "site" / "ppan_test.cylc").exists()
+    assert not (REPOSITORY_ROOT / "site" / "ppan.cylc").exists()
+    assert "platform = ppan_epmt" in epmt_site.read_text(encoding="utf-8")
+    assert "platform = ppan_noepmt" in noepmt_site.read_text(encoding="utf-8")
+    assert 'site:                    "ppan_epmt"' in local_settings.read_text(encoding="utf-8")
+    assert "[[ppan_epmt]]" in global_config.read_text(encoding="utf-8")
+    assert "[[ppan_noepmt]]" in global_config.read_text(encoding="utf-8")

--- a/lib/python/tool_ops_w_papiex.py
+++ b/lib/python/tool_ops_w_papiex.py
@@ -279,7 +279,7 @@ def annotate_metadata():
     accomplished by adding lines, that call `epmt annotate EPMT_JOB_TAGS=<dict>`, and
     parsing the job script for metadata of interest.
 
-    not yet implemented, challenging for a questionable amount of benefit. the Jinja2 calls in site/ppan_test.cylc
+    not yet implemented, challenging for a questionable amount of benefit. the Jinja2 calls in site/ppan_epmt.cylc
     are completely adequate for now
     '''
     raise NotImplementedError()

--- a/portable-post-processing.md
+++ b/portable-post-processing.md
@@ -67,8 +67,8 @@ s1[**gfdl-ws.cylc**:
 s2[**gaea.cylc**: 
     - uses platform = localhost
     - loads FRE_VERSION]
-s3[**ppan.cylc**:
-    - uses platform = ppan
+s3[**ppan_epmt.cylc** / **ppan_noepmt.cylc**:
+    - use platform = ppan_epmt / ppan_noepmt
     - includes gfdl/ppan specific tools
     - loads FRE_VERSION]
 end
@@ -82,7 +82,7 @@ end
 G["***global.cylc***:
     - located in ***~/.cylc/flow/***
     - includes information for each platform used in the site configs
-    - platforms include: **localhost (jobs run in background), ppan (jobs run on slurm)**
+    - platforms include: **localhost (jobs run in background), ppan_epmt / ppan_noepmt (jobs run on slurm)**
     - defines platform groups: ppan_background nodes
     - includes install directories for symlink locations: share, work"]
 

--- a/rose-suite.conf
+++ b/rose-suite.conf
@@ -1,6 +1,6 @@
 [template variables]
 ## Specify the site used 
-#SITE="ppan"
+#SITE="ppan_epmt"
 
 ## Switch to remove intermediate data files when they are no longer needed
 #CLEAN_WORK=True

--- a/site/ppan_epmt.cylc
+++ b/site/ppan_epmt.cylc
@@ -45,7 +45,7 @@
         {# execution retry delays = PT1M, PT5M, PT10M                                      #}
         # Set default time limit to 4 hours
         execution time limit = PT4H
-        platform = ppan_test
+        platform = ppan_epmt
         [[[directives]]]
             --comment=xtmp,epmt,fre/{{ FRE_VERSION }}
         [[[environment]]]

--- a/site/ppan_noepmt.cylc
+++ b/site/ppan_noepmt.cylc
@@ -28,7 +28,7 @@
         {# execution retry delays = PT1M, PT5M, PT10M                                      #}
         # Set default time limit to 4 hours
         execution time limit = PT4H
-        platform = ppan
+        platform = ppan_noepmt
         [[[directives]]]
             --comment=xtmp,fre/{{ FRE_VERSION }}
         [[[environment]]]


### PR DESCRIPTION
## Describe your changes

- Rename `ppan_test` to `ppan_epmt` and `ppan` to `ppan_noepmt` across site files, platform definitions, and workflow conditionals.
- Make `ppan_epmt` the documented/local default while retaining `ppan_noepmt` as the explicit opt-out.
- Update developer and portability docs and add a regression test for consistent site/platform names.

## Issue ticket number and link (if applicable)

Closes #172

## Checklist before requesting a review

- [x] I ran my code
- [x] I tried to make my code readable
- [x] I tried to comment my code
- [x] I wrote a new test, if applicable
- [x] I wrote new instructions/documentation, if applicable
- [x] I ran pytest and inspected it's output
- [x] I ran pylint and attempted to implement some of it's feedback
- [x] No print statements; all user-facing info uses logging module

## Validation

- `cylc lint -v` (passes, no issues)
- `pytest -q Jinja2Filters/tests lib/python/tests/test_site_names.py lib/python/tests/test_ppan_handler.py` (22 passed)
- `pylint --rcfile ./pylintrc --fail-under 9.8 ./lib/python` (9.83/10)
- `git diff --check`

## Manual Pipeline Run Details

**Was the manual pipeline (`test_cloud_runner`) triggered for this PR?**

- [ ] Yes
- [x] No

**Result of manual pipeline run:**

Awaiting a maintainer-triggered run using fork `ColumbusLabs/fre-workflows`, branch `codex-rename-ppan-sites`, and the appropriate `fre-cli` branch.